### PR TITLE
Fix shape-handling crashes for multi-output containers and multi-input shapes

### DIFF
--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -1,12 +1,6 @@
-"""Regression tests reproducing crashes reported in open GitHub issues.
+"""Regression tests for shape-handling crashes reported in open GitHub issues.
 
-Each test encodes the *desired* (fixed) behavior and is marked
-``xfail(strict=True)`` until the corresponding fix lands. Today they are
-expected to fail, which confirms the bug is reproduced. Once a fix is
-implemented, remove the matching ``xfail`` marker so the test turns into
-a permanent regression guard. ``strict=True`` makes pytest error out if a
-marker is left in place after the bug is actually fixed, so markers can't
-be forgotten.
+See https://github.com/willyfh/visualtorch/issues/63, /68, /69.
 """
 
 # Copyright (C) 2024 Willy Fitra Hendria
@@ -23,9 +17,8 @@ from visualtorch.utils.utils import self_multiply
 def multi_output_container_model() -> nn.Module:
     """A model whose inner block is a container (not Sequential/ModuleList) that returns multiple tensors.
 
-    This mirrors timm's ``FeatureListNet`` used in issue #69: ``register_hook`` hooks the
-    container itself (since it isn't ``nn.Sequential``/``nn.ModuleList``), capturing an
-    output shape that is a tuple of multiple ``torch.Size`` objects instead of a single one.
+    This mirrors timm's ``FeatureListNet`` used in issue #69: a container module that isn't
+    ``nn.Sequential``/``nn.ModuleList`` and returns multiple differently-shaped tensors.
     """
 
     class FeaturePyramidBlock(nn.Module):
@@ -52,32 +45,18 @@ def multi_output_container_model() -> nn.Module:
     return MultiScaleNet()
 
 
-@pytest.mark.xfail(
-    reason="visualtorch/issues/69: a container module with a multi-tensor output crashes layered_view",
-    strict=True,
-)
 def test_layered_view_multi_output_container(multi_output_container_model: nn.Module) -> None:
     """layered_view should not crash on container modules that output multiple tensors."""
     img = layered_view(multi_output_container_model, input_shape=(1, 3, 32, 32))
     assert img is not None
 
 
-@pytest.mark.xfail(
-    reason="visualtorch/issues/69: a container module with a multi-tensor output crashes lenet_view",
-    strict=True,
-)
 def test_lenet_view_multi_output_container(multi_output_container_model: nn.Module) -> None:
     """lenet_view should not crash on container modules that output multiple tensors."""
     img = lenet_view(multi_output_container_model, input_shape=(1, 3, 32, 32))
     assert img is not None
 
 
-@pytest.mark.xfail(
-    reason="visualtorch/issues/63: self_multiply returns a non-int when fed a nested shape "
-    "(e.g. a torch.Size captured from a multi-output module), which later breaks the "
-    "per-dimension box-size arithmetic in layered_view/lenet_view",
-    strict=True,
-)
 def test_self_multiply_handles_nested_shape() -> None:
     """self_multiply should always reduce to a scalar, even if an element is itself a shape."""
     nested_shape = (1, torch.Size([4, 8]))
@@ -85,11 +64,6 @@ def test_self_multiply_handles_nested_shape() -> None:
     assert isinstance(result, int)
 
 
-@pytest.mark.xfail(
-    reason="visualtorch/issues/68: passing a multi-input shape currently raises a cryptic "
-    "torch.rand TypeError instead of a clear, actionable validation error",
-    strict=True,
-)
 def test_lenet_view_rejects_multi_input_shape_with_clear_error() -> None:
     """Multi-tensor-input models aren't supported yet; the failure should be a clear ValueError."""
     model = nn.Linear(10, 5)

--- a/visualtorch/layered.py
+++ b/visualtorch/layered.py
@@ -22,6 +22,7 @@ from .utils.utils import (
     get_rgba_tuple,
     linear_layout,
     self_multiply,
+    validate_input_shape,
     vertical_image_concat,
 )
 
@@ -84,6 +85,8 @@ def layered_view(
         PIL.Image: An Image object representing the generated architecture visualization.
     """
     # Iterate over the model to compute bounds and generate boxes
+
+    validate_input_shape(input_shape)
 
     x_off = -1
 
@@ -291,7 +294,7 @@ def _create_architecture(
         layer = layers[key]["module"]
         shape = layers[key]["output_shape"]
         # Do no render the SpacingDummyLayer, just increase the pointer
-        if type(layer) == SpacingDummyLayer:
+        if type(layer) is SpacingDummyLayer:
             current_z += layer.spacing
             continue
 

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -19,6 +19,7 @@ from .utils.utils import (
     StackedBox,
     get_rgba_tuple,
     self_multiply,
+    validate_input_shape,
 )
 
 
@@ -81,6 +82,8 @@ def lenet_view(
         PIL.Image: An Image object representing the generated architecture visualization.
     """
     # Iterate over the model to compute bounds and generate boxes
+
+    validate_input_shape(input_shape)
 
     x_off = -1
 
@@ -247,7 +250,7 @@ def _create_architecture(
         layer = layers[key]["module"]
         shape = layers[key]["output_shape"]
         # Do no render the SpacingDummyLayer, just increase the pointer
-        if type(layer) == SpacingDummyLayer:
+        if type(layer) is SpacingDummyLayer:
             current_x += layer.spacing
             continue
 

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -185,7 +185,7 @@ def register_hook(
         m_key = "%s-%i" % (class_name, module_idx + 1)
         layers[m_key] = OrderedDict()
         layers[m_key]["module"] = module
-        if isinstance(out, (tuple, list)):
+        if isinstance(out, tuple | list):
             if len(out) > 0 and hasattr(out[0], "size"):
                 layers[m_key]["output_shape"] = out[0].size()
             else:

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -185,17 +185,20 @@ def register_hook(
         m_key = "%s-%i" % (class_name, module_idx + 1)
         layers[m_key] = OrderedDict()
         layers[m_key]["module"] = module
-        if isinstance(out, tuple):
-            if hasattr(out[0], "size"):
+        if isinstance(out, (tuple, list)):
+            if len(out) > 0 and hasattr(out[0], "size"):
                 layers[m_key]["output_shape"] = out[0].size()
             else:
                 layers[m_key]["output_shape"] = tuple(o.size() for o in out if hasattr(o, "size"))
-        elif isinstance(out, list):
-            layers[m_key]["output_shape"] = tuple(o.size() for o in out if hasattr(o, "size"))
         else:
             layers[m_key]["output_shape"] = out.size()
 
-    if not isinstance(module, nn.Sequential) and not isinstance(module, nn.ModuleList) and module is not model:
+    # Only hook leaf modules (no children). Container modules - whether nn.Sequential,
+    # nn.ModuleList, or a custom container such as timm's FeatureListNet - would otherwise be
+    # captured as if they were a single layer, with their multi-tensor output mistaken for one
+    # layer's output shape.
+    is_leaf = len(list(module.children())) == 0
+    if is_leaf and module is not model:
         hooks.append(module.register_forward_hook(hook))
 
 

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -280,7 +280,7 @@ def validate_input_shape(input_shape: tuple) -> None:
         raise ValueError(error_msg)
 
 
-def self_multiply(tensor_tuple: tuple) -> int | float:
+def self_multiply(tensor_tuple: tuple | list) -> int | float:
     """Multiplies all elements in the tuple together.
 
     Elements that are themselves a tuple/list (e.g. a nested torch.Size, which can end up here
@@ -288,7 +288,7 @@ def self_multiply(tensor_tuple: tuple) -> int | float:
     their own elements together first, so the result is always a scalar.
 
     Args:
-        tensor_tuple (tuple): A tuple containing tensors.
+        tensor_tuple (tuple or list): A tuple containing tensors.
 
     Returns:
         int or float: The result of multiplying all elements together.
@@ -298,7 +298,7 @@ def self_multiply(tensor_tuple: tuple) -> int | float:
         return 0
     s = 1
     for v in tensor_list:
-        s *= self_multiply(v) if isinstance(v, (tuple, list)) else v
+        s *= self_multiply(v) if isinstance(v, tuple | list) else v
     return s
 
 

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -261,8 +261,31 @@ def get_keys_by_value(d: dict, v: int) -> Generator:
             yield key
 
 
+def validate_input_shape(input_shape: tuple) -> None:
+    """Validate that input_shape describes a single input tensor.
+
+    Args:
+        input_shape (tuple): The shape to validate.
+
+    Raises:
+        ValueError: If input_shape is not a single flat tuple of ints, e.g. when a tuple of
+            per-tensor shapes was passed for a model that takes multiple separate input tensors.
+    """
+    if not isinstance(input_shape, tuple) or not all(isinstance(dim, int) for dim in input_shape):
+        error_msg = (
+            "input_shape must be a single tuple of ints, e.g. (1, 3, 224, 224). "
+            f"Got {input_shape!r} instead. Visualizing models that take multiple separate "
+            "input tensors is not supported yet."
+        )
+        raise ValueError(error_msg)
+
+
 def self_multiply(tensor_tuple: tuple) -> int | float:
     """Multiplies all elements in the tuple together.
+
+    Elements that are themselves a tuple/list (e.g. a nested torch.Size, which can end up here
+    when a layer's captured output shape wasn't a plain flat shape) are flattened by multiplying
+    their own elements together first, so the result is always a scalar.
 
     Args:
         tensor_tuple (tuple): A tuple containing tensors.
@@ -270,14 +293,12 @@ def self_multiply(tensor_tuple: tuple) -> int | float:
     Returns:
         int or float: The result of multiplying all elements together.
     """
-    tensor_list = list(tensor_tuple)
-    if None in tensor_list:
-        tensor_list.remove(None)
+    tensor_list = [v for v in tensor_tuple if v is not None]
     if len(tensor_list) == 0:
         return 0
-    s = tensor_list[0]
-    for i in range(1, len(tensor_list)):
-        s *= tensor_list[i]
+    s = 1
+    for v in tensor_list:
+        s *= self_multiply(v) if isinstance(v, (tuple, list)) else v
     return s
 
 


### PR DESCRIPTION
## Summary
- Fixes #63, #68, #69 — all three shared one root cause: `register_hook` hooked any module that wasn't `nn.Sequential`/`nn.ModuleList`, so custom container modules (e.g. timm's `FeatureListNet`) got captured as if they were a single layer, producing a multi-tensor output shape that crashed the per-dimension box-size arithmetic in `layered_view`/`lenet_view`.
- `register_hook` now only hooks leaf modules (`len(list(module.children())) == 0`), which naturally excludes `nn.Sequential`/`nn.ModuleList` and any custom container, without hardcoding types.
- `self_multiply` now defensively flattens any nested shape that still slips through, as a backstop.
- Added `validate_input_shape`, called at the top of `layered_view`/`lenet_view`, so passing a multi-input shape (tuple-of-tuples) now raises a clear `ValueError` instead of a cryptic `torch.rand()` TypeError (#68). Multi-input models themselves are still not supported — this only replaces a confusing crash with an actionable error.
- Small cleanup: `type(layer) == SpacingDummyLayer` → `is` (ruff flags `==` type comparisons).

This turns the 4 regression tests added in #70 from `xfail` into passing tests (markers removed).

## Test plan
- [x] `pytest tests/` — 13/13 passing (was 9 passed + 4 xfailed before this fix)
- [x] `ruff check visualtorch/` — no new lint findings introduced (15 pre-existing findings on main, 13 on this branch)