### PR TITLE
Expand test coverage for previously untested parameters

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,8 +3,11 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
+
 import pytest
 import torch
+from PIL import Image
 from torch import nn
 from visualtorch import graph_view
 
@@ -33,6 +36,63 @@ def dense_model() -> nn.Module:
     return SimpleDense()
 
 
+@pytest.fixture()
+def conv_model() -> nn.Module:
+    """A simple conv model, exercising the Conv2d/ConvolutionBackward0 path."""
+    return nn.Sequential(
+        nn.Conv2d(3, 8, 3, 1, 1),
+        nn.Conv2d(8, 16, 3, 1, 1),
+    )
+
+
+@pytest.fixture()
+def wide_dense_model() -> nn.Module:
+    """A dense model with a hidden layer wider than the default ellipsize_after threshold."""
+
+    class WideDense(nn.Module):
+        """A dense model with more than 10 hidden units, to trigger ellipsis drawing."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.h0 = nn.Linear(4, 20)
+            self.out = nn.Linear(20, 2)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass."""
+            return self.out(self.h0(x))
+
+    return WideDense()
+
+
 def test_dense_model_graph_view_runs(dense_model: nn.Module) -> None:
     """Test graph view using dense model."""
     _ = graph_view(dense_model, input_shape=(1, 4))
+
+
+def test_conv_model_graph_view_runs(conv_model: nn.Module) -> None:
+    """graph_view should support Conv2d layers, not just Linear."""
+    img = graph_view(conv_model, input_shape=(1, 3, 16, 16))
+    assert img is not None
+
+
+def test_graph_view_ellipsizes_wide_layers(wide_dense_model: nn.Module) -> None:
+    """A hidden layer wider than ellipsize_after should draw an ellipsis, not crash."""
+    img = graph_view(wide_dense_model, input_shape=(1, 4), ellipsize_after=10)
+    assert img is not None
+
+
+def test_graph_view_show_neurons_false(wide_dense_model: nn.Module) -> None:
+    """show_neurons=False should render one node per layer instead of per neuron."""
+    img = graph_view(wide_dense_model, input_shape=(1, 4), show_neurons=False)
+    assert img is not None
+
+
+def test_graph_view_writes_to_file(dense_model: nn.Module, tmp_path: Path) -> None:
+    """to_file should save a readable image to disk."""
+    out_file = tmp_path / "graph.png"
+    graph_view(dense_model, input_shape=(1, 4), to_file=str(out_file))
+
+    assert out_file.exists()
+    with Image.open(out_file) as saved_img:
+        assert saved_img.size[0] > 0
+        assert saved_img.size[1] > 0

--- a/tests/test_layered.py
+++ b/tests/test_layered.py
@@ -3,9 +3,12 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn.functional as func
+from PIL import Image
 from torch import nn
 from visualtorch import layered_view
 
@@ -78,6 +81,29 @@ def lstm_model() -> nn.Module:
     return LSTMModel(input_size=10, hidden_size=20, num_layers=2)
 
 
+@pytest.fixture()
+def classifier_model() -> nn.Module:
+    """Define a model ending in a 1D (per-sample) output, e.g. classification logits."""
+
+    class ClassifierModel(nn.Module):
+        """A cnn model that ends with a 1D output."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(3, 8, 3, 1, 1)
+            self.pool = nn.AdaptiveAvgPool2d(1)
+            self.fc = nn.Linear(8, 5)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass."""
+            x = self.conv(x)
+            x = self.pool(x)
+            x = torch.flatten(x, 1)
+            return self.fc(x)
+
+    return ClassifierModel()
+
+
 def test_sequential_model_layered_view_runs(sequential_model: nn.Sequential) -> None:
     """Test layered view on sequential model."""
     _ = layered_view(sequential_model, input_shape=(1, 3, 224, 224))
@@ -96,3 +122,44 @@ def test_custom_model_layered_view_runs(custom_model: nn.Module) -> None:
 def test_lstm_model_layered_view_runs(lstm_model: nn.Module) -> None:
     """Test layered view on lstm model."""
     _ = layered_view(lstm_model, input_shape=(1, 10, 10))
+
+
+@pytest.mark.parametrize("orientation", ["x", "y", "z"])
+def test_layered_view_one_dim_orientation(classifier_model: nn.Module, orientation: str) -> None:
+    """Test layered view on a model with a 1D output, for every supported orientation."""
+    img = layered_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation=orientation)
+    assert img is not None
+
+
+def test_layered_view_invalid_one_dim_orientation_raises(classifier_model: nn.Module) -> None:
+    """An unsupported one_dim_orientation should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="unsupported orientation"):
+        layered_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation="bad")
+
+
+def test_layered_view_with_type_and_index_ignore(sequential_model: nn.Sequential) -> None:
+    """Layers matched by type_ignore or index_ignore should be skipped without error."""
+    img = layered_view(
+        sequential_model,
+        input_shape=(1, 3, 224, 224),
+        type_ignore=[nn.ReLU],
+        index_ignore=[0],
+    )
+    assert img is not None
+
+
+def test_layered_view_with_legend(sequential_model: nn.Sequential) -> None:
+    """legend=True should append a legend without error."""
+    img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), legend=True)
+    assert img is not None
+
+
+def test_layered_view_writes_to_file(sequential_model: nn.Sequential, tmp_path: Path) -> None:
+    """to_file should save a readable image to disk."""
+    out_file = tmp_path / "layered.png"
+    layered_view(sequential_model, input_shape=(1, 3, 224, 224), to_file=str(out_file))
+
+    assert out_file.exists()
+    with Image.open(out_file) as saved_img:
+        assert saved_img.size[0] > 0
+        assert saved_img.size[1] > 0

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -3,9 +3,12 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn.functional as func
+from PIL import Image
 from torch import nn
 from visualtorch import lenet_view
 
@@ -78,6 +81,29 @@ def lstm_model() -> nn.Module:
     return LSTMModel(input_size=10, hidden_size=20, num_layers=2)
 
 
+@pytest.fixture()
+def classifier_model() -> nn.Module:
+    """Define a model ending in a 1D (per-sample) output, e.g. classification logits."""
+
+    class ClassifierModel(nn.Module):
+        """A cnn model that ends with a 1D output."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(3, 8, 3, 1, 1)
+            self.pool = nn.AdaptiveAvgPool2d(1)
+            self.fc = nn.Linear(8, 5)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass."""
+            x = self.conv(x)
+            x = self.pool(x)
+            x = torch.flatten(x, 1)
+            return self.fc(x)
+
+    return ClassifierModel()
+
+
 def test_sequential_model_lenet_view_runs(sequential_model: nn.Sequential) -> None:
     """Test lenet view on sequential model."""
     _ = lenet_view(sequential_model, input_shape=(1, 3, 224, 224))
@@ -96,3 +122,38 @@ def test_custom_model_lenet_view_runs(custom_model: nn.Module) -> None:
 def test_lstm_model_layered_view_runs(lstm_model: nn.Module) -> None:
     """Test layered view on lstm model."""
     _ = lenet_view(lstm_model, input_shape=(1, 10, 10))
+
+
+@pytest.mark.parametrize("orientation", ["x", "y", "z"])
+def test_lenet_view_one_dim_orientation(classifier_model: nn.Module, orientation: str) -> None:
+    """Test lenet view on a model with a 1D output, for every supported orientation."""
+    img = lenet_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation=orientation)
+    assert img is not None
+
+
+def test_lenet_view_invalid_one_dim_orientation_raises(classifier_model: nn.Module) -> None:
+    """An unsupported one_dim_orientation should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="unsupported orientation"):
+        lenet_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation="bad")
+
+
+def test_lenet_view_with_type_and_index_ignore(sequential_model: nn.Sequential) -> None:
+    """Layers matched by type_ignore or index_ignore should be skipped without error."""
+    img = lenet_view(
+        sequential_model,
+        input_shape=(1, 3, 224, 224),
+        type_ignore=[nn.ReLU],
+        index_ignore=[0],
+    )
+    assert img is not None
+
+
+def test_lenet_view_writes_to_file(sequential_model: nn.Sequential, tmp_path: Path) -> None:
+    """to_file should save a readable image to disk."""
+    out_file = tmp_path / "lenet.png"
+    lenet_view(sequential_model, input_shape=(1, 3, 224, 224), to_file=str(out_file))
+
+    assert out_file.exists()
+    with Image.open(out_file) as saved_img:
+        assert saved_img.size[0] > 0
+        assert saved_img.size[1] > 0


### PR DESCRIPTION
## Summary
Follow-up to #71 — closes the coverage gaps identified while verifying that fix didn't change existing behavior (existing tests only smoke-test the default happy path per view function).

Adds:
- `layered_view`/`lenet_view`: `one_dim_orientation` for all 3 axes + the invalid-value `ValueError` path, `type_ignore`/`index_ignore`, `to_file` writing (asserts the file actually exists and is a readable image)
- `layered_view`: `legend=True`
- `graph_view`: a `Conv2d` model (previously only `Linear`/`AddmmBackward0` was exercised, leaving the `ConvolutionBackward0` branch of `TARGET_OPS` untested), `ellipsize_after` on a layer wider than the threshold, `show_neurons=False`, `to_file` writing

Not in scope: exhaustive coverage of every parameter/combination, or the branching/skip-connection architecture gap in `graph_view` (bigger, separate effort).

## Test plan
- [x] `pytest tests/` — 30/30 passing (up from 13)
- [x] `pre-commit run --all-files` — all hooks pass