### PR TITLE
Replace graph_view's hardcoded TARGET_OPS with generic module tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ max-complexity = 15
 
 [tool.ruff.per-file-ignores]
 "tests/nightly/tools/benchmarking/test_benchmarking.py" = ["E402"]
+# RecorderTensor overrides torch.Tensor.__torch_function__, whose own signature is untyped
+# (Any throughout); the recursive tensor-structure helpers here genuinely accept arbitrary
+# nested types (tensors, tuples, dicts, non-tensor values) for the same reason.
+"visualtorch/utils/recorder.py" = ["ANN401", "ANN102"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,6 +10,7 @@ import torch
 from PIL import Image
 from torch import nn
 from visualtorch import graph_view
+from visualtorch.utils.layer_utils import model_to_adj_matrix
 
 
 @pytest.fixture()
@@ -64,6 +65,40 @@ def wide_dense_model() -> nn.Module:
     return WideDense()
 
 
+@pytest.fixture()
+def residual_model() -> nn.Module:
+    """A model with a skip connection around a hidden sub-block, to prove branching is captured."""
+
+    class ResidualBlock(nn.Module):
+        """fc1->fc2 with a skip connection from stem's output, merged into out."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.stem = nn.Linear(4, 4)
+            self.fc1 = nn.Linear(4, 4)
+            self.fc2 = nn.Linear(4, 4)
+            self.out = nn.Linear(4, 2)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass with a skip connection around fc1/fc2."""
+            stem_out = self.stem(x)
+            branch = self.fc2(self.fc1(stem_out))
+            merged = branch + stem_out
+            return self.out(merged)
+
+    return ResidualBlock()
+
+
+@pytest.fixture()
+def batchnorm_model() -> nn.Module:
+    """A model using BatchNorm2d, a layer type never supported by the old hardcoded TARGET_OPS."""
+    return nn.Sequential(
+        nn.Conv2d(3, 8, 3, 1, 1),
+        nn.BatchNorm2d(8),
+        nn.ReLU(),
+    )
+
+
 def test_dense_model_graph_view_runs(dense_model: nn.Module) -> None:
     """Test graph view using dense model."""
     _ = graph_view(dense_model, input_shape=(1, 4))
@@ -96,3 +131,44 @@ def test_graph_view_writes_to_file(dense_model: nn.Module, tmp_path: Path) -> No
     with Image.open(out_file) as saved_img:
         assert saved_img.size[0] > 0
         assert saved_img.size[1] > 0
+
+
+def test_graph_view_residual_model_runs(residual_model: nn.Module) -> None:
+    """graph_view should not crash on a model with a skip connection."""
+    img = graph_view(residual_model, input_shape=(1, 4))
+    assert img is not None
+
+
+def test_graph_view_batchnorm_model_runs(batchnorm_model: nn.Module) -> None:
+    """graph_view should not crash on a model using an untracked layer type (BatchNorm2d)."""
+    img = graph_view(batchnorm_model, input_shape=(2, 3, 8, 8))
+    assert img is not None
+
+
+def test_model_to_adj_matrix_edge_count_dense_model(dense_model: nn.Module) -> None:
+    """model_to_adj_matrix should produce exactly the expected edges for a known simple chain."""
+    _, adj_matrix, model_layers = model_to_adj_matrix(dense_model, input_shape=(1, 4))
+
+    # 4 chained Linear layers => exactly 3 edges, one layer per column.
+    assert int(adj_matrix.sum()) == 3
+    assert len(model_layers) == 4
+    for column in model_layers:
+        assert len(column) == 1
+
+
+def test_model_to_adj_matrix_captures_branching(residual_model: nn.Module) -> None:
+    """The merge point of a skip connection should have 2 incoming edges, not 1."""
+    id_to_index, adj_matrix, _ = model_to_adj_matrix(residual_model, input_shape=(1, 4))
+
+    out_node_id = str(id(residual_model.out))
+    in_degree = adj_matrix[:, id_to_index[out_node_id]].sum()
+
+    assert in_degree == 2, "expected the merge node to have 2 incoming edges from the skip connection"
+
+
+def test_model_to_adj_matrix_supports_untracked_layer_type(batchnorm_model: nn.Module) -> None:
+    """A BatchNorm2d instance should actually appear among the traced layers."""
+    _, _, model_layers = model_to_adj_matrix(batchnorm_model, input_shape=(2, 3, 8, 8))
+
+    traced_types = {type(wrapper.module) for column in model_layers for wrapper in column}
+    assert nn.BatchNorm2d in traced_types

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -147,7 +147,7 @@ def test_graph_view_batchnorm_model_runs(batchnorm_model: nn.Module) -> None:
 
 def test_model_to_adj_matrix_edge_count_dense_model(dense_model: nn.Module) -> None:
     """model_to_adj_matrix should produce exactly the expected edges for a known simple chain."""
-    _, adj_matrix, model_layers = model_to_adj_matrix(dense_model, input_shape=(1, 4))
+    _, adj_matrix, model_layers, _ = model_to_adj_matrix(dense_model, input_shape=(1, 4))
 
     # 4 chained Linear layers => exactly 3 edges, one layer per column.
     assert int(adj_matrix.sum()) == 3
@@ -158,9 +158,9 @@ def test_model_to_adj_matrix_edge_count_dense_model(dense_model: nn.Module) -> N
 
 def test_model_to_adj_matrix_captures_branching(residual_model: nn.Module) -> None:
     """The merge point of a skip connection should have 2 incoming edges, not 1."""
-    id_to_index, adj_matrix, _ = model_to_adj_matrix(residual_model, input_shape=(1, 4))
+    id_to_index, adj_matrix, _, _ = model_to_adj_matrix(residual_model, input_shape=(1, 4))
 
-    out_node_id = str(id(residual_model.out))
+    out_node_id = f"{id(residual_model.out)}#0"
     in_degree = adj_matrix[:, id_to_index[out_node_id]].sum()
 
     assert in_degree == 2, "expected the merge node to have 2 incoming edges from the skip connection"
@@ -168,7 +168,80 @@ def test_model_to_adj_matrix_captures_branching(residual_model: nn.Module) -> No
 
 def test_model_to_adj_matrix_supports_untracked_layer_type(batchnorm_model: nn.Module) -> None:
     """A BatchNorm2d instance should actually appear among the traced layers."""
-    _, _, model_layers = model_to_adj_matrix(batchnorm_model, input_shape=(2, 3, 8, 8))
+    _, _, model_layers, _ = model_to_adj_matrix(batchnorm_model, input_shape=(2, 3, 8, 8))
 
     traced_types = {type(wrapper.module) for column in model_layers for wrapper in column}
     assert nn.BatchNorm2d in traced_types
+
+
+def test_graph_view_supports_weight_sharing() -> None:
+    """A leaf module invoked more than once in one forward pass should not crash."""
+
+    class SharedModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            x = self.fc(x)
+            return self.fc(x)
+
+    img = graph_view(SharedModel(), input_shape=(1, 4))
+    assert img is not None
+
+
+def test_graph_view_bare_leaf_module_as_model() -> None:
+    """Passing a single leaf module (no children) directly as the model should not crash."""
+    img = graph_view(nn.Linear(4, 2), input_shape=(1, 4))
+    assert img is not None
+
+
+def test_model_to_adj_matrix_wires_deeper_direct_input_consumer() -> None:
+    """A node that reads the raw input directly, in addition to a hidden predecessor, still gets its input edge."""
+
+    class M(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.a = nn.Linear(4, 4)
+            self.b = nn.Linear(4, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            a = self.a(x)
+            return self.b(x + a)
+
+    model = M()
+    _, _, _, direct_input_node_ids = model_to_adj_matrix(model, input_shape=(1, 4))
+
+    b_node_id = next(node_id for node_id in direct_input_node_ids if node_id.startswith(f"{id(model.b)}#"))
+    assert b_node_id is not None
+
+
+def test_model_to_adj_matrix_survives_subclass_escaping_op() -> None:
+    """Lineage should survive a leaf module whose forward escapes the tensor subclass internally."""
+
+    class NumpyRoundTrip(nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            arr = x.detach().numpy()
+            return torch.from_numpy(arr.copy())
+
+    class M(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.a = nn.Linear(4, 4)
+            self.roundtrip = NumpyRoundTrip()
+            self.b = nn.Linear(4, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            x = self.a(x)
+            x = self.roundtrip(x)
+            return self.b(x)
+
+    model = M()
+    _, adj_matrix, model_layers, _ = model_to_adj_matrix(model, input_shape=(1, 4))
+
+    assert int(adj_matrix.sum()) == 2
+    assert [type(wrapper.module).__name__ for column in model_layers for wrapper in column] == [
+        "Linear",
+        "NumpyRoundTrip",
+        "Linear",
+    ]

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -13,7 +13,8 @@ import numpy as np
 import torch
 from PIL import Image
 
-from .utils.layer_utils import TARGET_OPS, add_input_dummy_layer, model_to_adj_matrix
+from .utils.layer_utils import add_input_dummy_layer, model_to_adj_matrix
+from .utils.traced_layer import TracedLayer
 from .utils.utils import Box, Circle, Ellipses, get_keys_by_value
 
 
@@ -167,25 +168,30 @@ def _draw_connector(
     draw.line([x1, y1, x2, y2], pen)
 
 
-def _retrieve_isbox_units(layer: torch.autograd.Function, show_neurons: bool) -> tuple[bool, int]:
-    """Return the number of units and the flag whether to visualize using a box or not."""
+def _retrieve_isbox_units(layer: TracedLayer, show_neurons: bool) -> tuple[bool, int]:
+    """Return the number of units and the flag whether to visualize using a box or not.
+
+    Units are derived generically from the layer's already-known output shape (dropping the
+    batch dim) rather than from private autograd attributes tied to a hardcoded op list:
+    a 1D output (e.g. Linear) uses its only dim as the unit count, a 3D output (e.g. Conv,
+    channels-first) uses the channel dim, and anything else (e.g. an RNN's (seq, hidden))
+    falls back to its last dim.
+    """
     is_box = True
     units = 1
     if show_neurons:
-        if hasattr(layer, "_saved_bias_sym_sizes_opt"):
+        dims = layer.output_shape[1:]
+        if len(dims) in (1, 3):
             is_box = False
-            units = layer._saved_bias_sym_sizes_opt[0]  # noqa: SLF001
-        elif hasattr(layer, "_saved_mat2_sym_sizes"):
+            units = dims[0]
+        elif len(dims) >= 2:
             is_box = False
-            units = layer._saved_mat2_sym_sizes[1]  # noqa: SLF001
-        elif hasattr(layer, "units"):  # for dummy input layer
-            is_box = False
-            units = layer.units
+            units = dims[-1]
     return is_box, units
 
 
 def _create_architecture(
-    model_layers: list[list],
+    model_layers: list[list[TracedLayer]],
     current_x: int,
     show_neurons: bool,
     ellipsize_after: int,
@@ -202,9 +208,10 @@ def _create_architecture(
     for layer_list in model_layers:
         current_y = 0
         nodes = []
-        layer: Any
+        layer: TracedLayer
         for layer in layer_list:
             is_box, units = _retrieve_isbox_units(layer, show_neurons)
+            layer_type = type(layer.module)
 
             n = min(units, ellipsize_after)
             layer_nodes = []
@@ -226,17 +233,17 @@ def _create_architecture(
                 current_y = c.y2 + node_spacing
 
                 c.set_fill(
-                    color_map.get(TARGET_OPS[layer.name()], {}).get("fill", "#ADD8E6"),
+                    color_map.get(layer_type, {}).get("fill", "#ADD8E6"),
                     opacity,
                 )
-                c.outline = color_map.get(TARGET_OPS[layer.name()], {}).get(
+                c.outline = color_map.get(layer_type, {}).get(
                     "outline",
                     "black",
                 )
 
                 layer_nodes.append(c)
 
-            id_to_node_list_map[str(id(layer))] = layer_nodes
+            id_to_node_list_map[layer.node_id] = layer_nodes
             nodes.extend(layer_nodes)
             current_y += 2 * node_size
 

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -68,7 +68,7 @@ def graph_view(
 
     # Attach helper layers
 
-    id_to_num_mapping, adj_matrix, model_layers = model_to_adj_matrix(
+    id_to_num_mapping, adj_matrix, model_layers, direct_input_node_ids = model_to_adj_matrix(
         model,
         input_shape,
     )
@@ -80,6 +80,7 @@ def graph_view(
         id_to_num_mapping,
         adj_matrix,
         model_layers,
+        direct_input_node_ids,
     )
 
     # Create architecture

--- a/visualtorch/utils/__init__.py
+++ b/visualtorch/utils/__init__.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 from .layer_utils import (
-    TARGET_OPS,
     InputDummyLayer,
     SpacingDummyLayer,
     add_input_dummy_layer,
@@ -39,6 +38,5 @@ __all__ = [
     "InputDummyLayer",
     "add_input_dummy_layer",
     "model_to_adj_matrix",
-    "TARGET_OPS",
     "register_hook",
 ]

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -4,22 +4,14 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
-from collections import OrderedDict, defaultdict
-from typing import Any
+from collections import OrderedDict, deque
 
 import numpy as np
 import torch
 from torch import nn
 
-from .utils import get_keys_by_value
-
-# WARNING: currently, graph visualization relying on following operations,
-# thereby only linear and convolutional layers are supported.
-# We need to implement a more dynamic/better approach to support all layers
-TARGET_OPS = defaultdict(
-    lambda: None,
-    {"AddmmBackward0": nn.Linear, "ConvolutionBackward0": nn.Conv2d},
-)
+from .recorder import trace_module_graph
+from .traced_layer import TracedLayer
 
 
 class SpacingDummyLayer(nn.Module):
@@ -46,8 +38,12 @@ class InputDummyLayer:
 def model_to_adj_matrix(
     model: nn.Module | nn.Sequential,
     input_shape: tuple[int, ...],
-) -> tuple[dict[str, int], np.ndarray, list[list[torch.nn.Module]]]:
+) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]]]:
     """Extract adjacency matrix representation from a pytorch model.
+
+    Traces an actual forward pass (see `visualtorch.utils.recorder.trace_module_graph`) instead of
+    walking the autograd backward graph, so any leaf module type is supported (not just a
+    hardcoded list), and branching/skip-connections are captured naturally.
 
     Args:
         model: PyTorch model.
@@ -58,65 +54,52 @@ def model_to_adj_matrix(
             - id_to_index_adj_mapping (dict): Mapping from node IDs to their corresponding index in
                 the adjacency matrix.
             - adjacency_matrix (numpy.ndarray): The adjacency matrix representing connections between
-                model operations/layers.
-            - model_layers (list): List of model layers organized by their hierarchy.
+                model layers.
+            - model_layers (list): List of `TracedLayer` wrappers organized by their hierarchy.
     """
-    dummy_input = torch.rand(input_shape)
-    output_var = model(dummy_input)
+    id_to_module, id_to_output_shape, edges, input_id = trace_module_graph(model, input_shape)
 
-    nodes: list = []
-    edges: list = []
-    id_to_ops: dict = {}
+    nodes = list(id_to_module.keys())
+    id_to_index_adj_mapping = {node_id: idx for idx, node_id in enumerate(nodes)}
 
-    max_level = [0]
-    max_level_id = [""]
-
-    # Extract nodes and edges for the target ops
-    # Currently only the ones in the TARGET_OPS are supported.
-
-    # handle multiple outputs
-    if isinstance(output_var, tuple):
-        for v in output_var:
-            _add_base_tensor(v, id_to_ops, nodes, edges, max_level, max_level_id)
-    else:
-        _add_base_tensor(output_var, id_to_ops, nodes, edges, max_level, max_level_id)
-
-    # Create adjacency matrix
     adjacency_matrix = np.zeros((len(nodes), len(nodes)))
-    id_to_index_adj_mapping = {node: idx for idx, node in enumerate(nodes)}
-
+    successors: dict[str, list[str]] = {node_id: [] for node_id in nodes}
+    in_degree: dict[str, int] = {node_id: 0 for node_id in nodes}
     for src_id, trg_id in edges:
-        if trg_id is not None:
-            src_index = id_to_index_adj_mapping[src_id]
-            trg_index = id_to_index_adj_mapping[trg_id]
-            adjacency_matrix[src_index, trg_index] += 1
+        if src_id == input_id:
+            continue
+        adjacency_matrix[id_to_index_adj_mapping[src_id], id_to_index_adj_mapping[trg_id]] += 1
+        successors[src_id].append(trg_id)
+        in_degree[trg_id] += 1
 
-    # Retrieve layers per level
-    input_layer_id = max_level_id[0]
-    temp_model_layers = [[input_layer_id]]
+    # Longest-path-from-source layering: a node's depth is 1 + the max depth of its
+    # predecessors (0 if it has none), computed via topological order so a merge node
+    # (e.g. the far side of a skip connection) is never placed before a branch that
+    # hasn't converged yet.
+    depth: dict[str, int] = {}
+    queue: deque[str] = deque()
+    for node_id in nodes:
+        if in_degree[node_id] == 0:
+            depth[node_id] = 0
+            queue.append(node_id)
 
-    while len(temp_model_layers) < max_level[0]:
-        prev_layers = temp_model_layers[-1]
-        new_layer = []
-        for layer_id in prev_layers:
-            src_index = id_to_index_adj_mapping[layer_id]
-            for trg_idx in np.where(adjacency_matrix[src_index] > 0)[0]:
-                trg_id = next(get_keys_by_value(id_to_index_adj_mapping, trg_idx))
-                new_layer.append(trg_id)
+    while queue:
+        node_id = queue.popleft()
+        for succ_id in successors[node_id]:
+            depth[succ_id] = max(depth.get(succ_id, 0), depth[node_id] + 1)
+            in_degree[succ_id] -= 1
+            if in_degree[succ_id] == 0:
+                queue.append(succ_id)
 
-        temp_model_layers.append(list(new_layer))
-
-    # Filter duplicate layers
-    seen = set()
-    model_layers: list[list] = []
-    for i in range(len(temp_model_layers) - 1, -1, -1):
-        new_layers = []
-        for layer_id in temp_model_layers[i]:
-            if layer_id in seen:
-                continue
-            seen.add(layer_id)
-            new_layers.append(id_to_ops[layer_id])
-        model_layers.insert(0, list(new_layers))
+    max_depth = max(depth.values(), default=-1)
+    model_layers: list[list[TracedLayer]] = [[] for _ in range(max_depth + 1)]
+    for node_id in nodes:
+        wrapper = TracedLayer(
+            module=id_to_module[node_id],
+            output_shape=id_to_output_shape[node_id],
+            node_id=node_id,
+        )
+        model_layers[depth[node_id]].append(wrapper)
 
     return id_to_index_adj_mapping, adjacency_matrix, model_layers
 
@@ -125,15 +108,15 @@ def add_input_dummy_layer(
     input_shape: tuple[int, ...],
     id_to_num_mapping: dict[str, int],
     adj_matrix: np.ndarray,
-    model_layers: list[list[Any]],
-) -> tuple[dict[str, int], np.ndarray, list[list[str]]]:
+    model_layers: list[list[TracedLayer]],
+) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]]]:
     """Add an input dummy layer to the model layers and update the adjacency matrix accordingly.
 
     Args:
         input_shape (tuple): The shape of the input tensor.
         id_to_num_mapping (dict): Mapping from node IDs to their corresponding index in the adjacency matrix.
-        adj_matrix (numpy.ndarray): The adjacency matrix representing connections between model operations.
-        model_layers (list): List of model layers organized by their dependencies.
+        adj_matrix (numpy.ndarray): The adjacency matrix representing connections between model layers.
+        model_layers (list): List of `TracedLayer` wrappers organized by their dependencies.
 
     Returns:
         tuple: A tuple containing:
@@ -142,17 +125,24 @@ def add_input_dummy_layer(
             - adj_matrix (numpy.ndarray): Updated adjacency matrix.
             - model_layers (list): Updated list of model layers with the input dummy layer.
     """
-    first_hidden_layer = model_layers[0][0]
-    input_dummy_layer = InputDummyLayer("input", input_shape[1])
+    first_layer = model_layers[0]
+    input_node_id = "__input_dummy__"
+    input_dummy_layer = TracedLayer(
+        module=InputDummyLayer("input", input_shape[1]),
+        output_shape=input_shape,
+        node_id=input_node_id,
+    )
     model_layers.insert(0, [input_dummy_layer])
-    id_to_num_mapping[str(id(input_dummy_layer))] = len(id_to_num_mapping.keys())
+    id_to_num_mapping[input_node_id] = len(id_to_num_mapping.keys())
     adj_matrix = np.pad(
         adj_matrix,
         ((0, 1), (0, 1)),
         mode="constant",
         constant_values=0,
     )
-    adj_matrix[-1, id_to_num_mapping[str(id(first_hidden_layer))]] += 1
+    input_index = id_to_num_mapping[input_node_id]
+    for layer in first_layer:
+        adj_matrix[input_index, id_to_num_mapping[layer.node_id]] += 1
     return id_to_num_mapping, adj_matrix, model_layers
 
 
@@ -200,50 +190,3 @@ def register_hook(
     is_leaf = len(list(module.children())) == 0
     if is_leaf and module is not model:
         hooks.append(module.register_forward_hook(hook))
-
-
-def _add_nodes(
-    fn: torch.autograd.function,
-    id_to_ops: dict,
-    nodes: list,
-    edges: list,
-    max_level: list[int],
-    max_level_id: list[str],
-    source: str | None = None,
-    level: int = 0,
-) -> None:
-    assert not torch.is_tensor(fn)
-
-    if str(type(fn).__name__) in TARGET_OPS:
-        node_id = str(id(fn))
-        id_to_ops[node_id] = fn
-        if node_id not in nodes:
-            nodes.append(node_id)
-        level += 1
-        if level > max_level[0]:
-            max_level[0] = level
-            max_level_id[0] = node_id
-
-        edges.append((node_id, source))
-        source = node_id
-
-    # recurse
-    if hasattr(fn, "next_functions"):
-        for u in fn.next_functions:
-            if u[0] is not None:
-                _add_nodes(u[0], id_to_ops, nodes, edges, max_level, max_level_id, source, level)
-
-
-def _add_base_tensor(
-    var: torch.Tensor,
-    id_to_ops: dict,
-    nodes: list,
-    edges: list,
-    max_level: list[int],
-    max_level_id: list[str],
-) -> None:
-    if var.grad_fn:
-        _add_nodes(var.grad_fn, id_to_ops, nodes, edges, max_level, max_level_id)
-
-    if var._is_view():  # noqa: SLF001
-        _add_base_tensor(var._base, id_to_ops, nodes, edges, max_level, max_level_id)  # noqa: SLF001

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -38,7 +38,7 @@ class InputDummyLayer:
 def model_to_adj_matrix(
     model: nn.Module | nn.Sequential,
     input_shape: tuple[int, ...],
-) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]]]:
+) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]], set[str]]:
     """Extract adjacency matrix representation from a pytorch model.
 
     Traces an actual forward pass (see `visualtorch.utils.recorder.trace_module_graph`) instead of
@@ -56,17 +56,23 @@ def model_to_adj_matrix(
             - adjacency_matrix (numpy.ndarray): The adjacency matrix representing connections between
                 model layers.
             - model_layers (list): List of `TracedLayer` wrappers organized by their hierarchy.
+            - direct_input_node_ids (set): Node ids that consume the traced input tensor directly,
+                for `add_input_dummy_layer` to wire up - not just whichever nodes end up at depth 0,
+                since a node can consume the raw input directly *and* have other predecessors (e.g.
+                the far side of a skip connection around a hidden sub-block).
     """
     id_to_module, id_to_output_shape, edges, input_id = trace_module_graph(model, input_shape)
 
     nodes = list(id_to_module.keys())
     id_to_index_adj_mapping = {node_id: idx for idx, node_id in enumerate(nodes)}
 
+    direct_input_node_ids: set[str] = set()
     adjacency_matrix = np.zeros((len(nodes), len(nodes)))
     successors: dict[str, list[str]] = {node_id: [] for node_id in nodes}
     in_degree: dict[str, int] = {node_id: 0 for node_id in nodes}
     for src_id, trg_id in edges:
         if src_id == input_id:
+            direct_input_node_ids.add(trg_id)
             continue
         adjacency_matrix[id_to_index_adj_mapping[src_id], id_to_index_adj_mapping[trg_id]] += 1
         successors[src_id].append(trg_id)
@@ -101,7 +107,7 @@ def model_to_adj_matrix(
         )
         model_layers[depth[node_id]].append(wrapper)
 
-    return id_to_index_adj_mapping, adjacency_matrix, model_layers
+    return id_to_index_adj_mapping, adjacency_matrix, model_layers, direct_input_node_ids
 
 
 def add_input_dummy_layer(
@@ -109,6 +115,7 @@ def add_input_dummy_layer(
     id_to_num_mapping: dict[str, int],
     adj_matrix: np.ndarray,
     model_layers: list[list[TracedLayer]],
+    direct_input_node_ids: set[str],
 ) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]]]:
     """Add an input dummy layer to the model layers and update the adjacency matrix accordingly.
 
@@ -117,6 +124,8 @@ def add_input_dummy_layer(
         id_to_num_mapping (dict): Mapping from node IDs to their corresponding index in the adjacency matrix.
         adj_matrix (numpy.ndarray): The adjacency matrix representing connections between model layers.
         model_layers (list): List of `TracedLayer` wrappers organized by their dependencies.
+        direct_input_node_ids (set): Node ids that consume the input directly (from
+            `model_to_adj_matrix`), wired up regardless of which depth they ended up at.
 
     Returns:
         tuple: A tuple containing:
@@ -125,7 +134,6 @@ def add_input_dummy_layer(
             - adj_matrix (numpy.ndarray): Updated adjacency matrix.
             - model_layers (list): Updated list of model layers with the input dummy layer.
     """
-    first_layer = model_layers[0]
     input_node_id = "__input_dummy__"
     input_dummy_layer = TracedLayer(
         module=InputDummyLayer("input", input_shape[1]),
@@ -141,8 +149,8 @@ def add_input_dummy_layer(
         constant_values=0,
     )
     input_index = id_to_num_mapping[input_node_id]
-    for layer in first_layer:
-        adj_matrix[input_index, id_to_num_mapping[layer.node_id]] += 1
+    for node_id in direct_input_node_ids:
+        adj_matrix[input_index, id_to_num_mapping[node_id]] += 1
     return id_to_num_mapping, adj_matrix, model_layers
 
 

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -122,8 +122,7 @@ def _wrapped_module_call(
             node_id = str(id(mod))
             id_to_module[node_id] = mod
             id_to_output_shape[node_id] = _first_tensor_shape(out)
-            for producer_id in producer_ids:
-                edges.append((producer_id, node_id))
+            edges.extend((producer_id, node_id) for producer_id in producer_ids)
             _stamp_producer_ids(out, {node_id})
 
         return out
@@ -147,6 +146,7 @@ class Recorder:
         self._edges = edges
 
     def __enter__(self) -> "Recorder":
+        """Patch nn.Module.__call__ to start tracing."""
         nn.Module.__call__ = _wrapped_module_call(  # type: ignore[method-assign]
             self._model,
             self._id_to_module,
@@ -156,6 +156,7 @@ class Recorder:
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
+        """Restore the original nn.Module.__call__."""
         nn.Module.__call__ = _orig_module_call  # type: ignore[method-assign]
 
 

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -82,6 +82,30 @@ def _stamp_producer_ids(obj: Any, ids: set[str]) -> None:
             _stamp_producer_ids(value, ids)
 
 
+def _wrap_and_stamp(obj: Any, ids: set[str]) -> Any:
+    """Like _stamp_producer_ids, but also converts plain (non-RecorderTensor) tensors.
+
+    A leaf module's forward can internally escape the tensor subclass (e.g. a numpy
+    round-trip), which would otherwise silently break lineage tracking for everything
+    downstream of that module. Re-wrapping at the module-call boundary re-establishes it
+    regardless of what happened inside.
+    """
+    if isinstance(obj, RecorderTensor):
+        obj._producer_ids = set(ids)  # noqa: SLF001
+        return obj
+    if isinstance(obj, torch.Tensor):
+        wrapped = obj.as_subclass(RecorderTensor)
+        wrapped._producer_ids = set(ids)  # noqa: SLF001
+        return wrapped
+    if isinstance(obj, Mapping):
+        return type(obj)({key: _wrap_and_stamp(value, ids) for key, value in obj.items()})  # type: ignore[call-arg]
+    if isinstance(obj, tuple):
+        return type(obj)(_wrap_and_stamp(value, ids) for value in obj)  # type: ignore[call-arg]
+    if isinstance(obj, list):
+        return [_wrap_and_stamp(value, ids) for value in obj]
+    return obj
+
+
 def _first_tensor_shape(obj: Any) -> tuple[int, ...]:
     """Recursively find the shape of the first tensor inside obj, or () if there isn't one."""
     if isinstance(obj, torch.Tensor):
@@ -102,10 +126,10 @@ def _first_tensor_shape(obj: Any) -> tuple[int, ...]:
 
 
 def _wrapped_module_call(
-    model: nn.Module,
     id_to_module: dict[str, nn.Module],
     id_to_output_shape: dict[str, tuple[int, ...]],
     edges: list[tuple[str, str]],
+    call_counts: dict[int, int],
 ) -> Any:
     """Build the replacement for nn.Module.__call__ used while tracing."""
 
@@ -116,14 +140,21 @@ def _wrapped_module_call(
 
         # Only leaf modules (no children) become graph nodes - containers such as
         # nn.Sequential or a custom composite block are transparent plumbing, matching the
-        # leaf definition already used by register_hook for layered_view/lenet_view.
+        # leaf definition already used by register_hook for layered_view/lenet_view. A leaf
+        # module invoked more than once (e.g. weight sharing) gets a distinct node per call,
+        # keyed by a call-index suffix, so repeat calls don't collapse into a self-referential
+        # node that can never be placed in the topological layering.
         is_leaf = len(list(mod.children())) == 0
-        if is_leaf and mod is not model:
-            node_id = str(id(mod))
+        if is_leaf:
+            base_id = id(mod)
+            call_index = call_counts.get(base_id, 0)
+            call_counts[base_id] = call_index + 1
+            node_id = f"{base_id}#{call_index}"
+
             id_to_module[node_id] = mod
             id_to_output_shape[node_id] = _first_tensor_shape(out)
             edges.extend((producer_id, node_id) for producer_id in producer_ids)
-            _stamp_producer_ids(out, {node_id})
+            out = _wrap_and_stamp(out, {node_id})
 
         return out
 
@@ -135,23 +166,23 @@ class Recorder:
 
     def __init__(
         self,
-        model: nn.Module,
         id_to_module: dict[str, nn.Module],
         id_to_output_shape: dict[str, tuple[int, ...]],
         edges: list[tuple[str, str]],
+        call_counts: dict[int, int],
     ) -> None:
-        self._model = model
         self._id_to_module = id_to_module
         self._id_to_output_shape = id_to_output_shape
         self._edges = edges
+        self._call_counts = call_counts
 
     def __enter__(self) -> "Recorder":
         """Patch nn.Module.__call__ to start tracing."""
         nn.Module.__call__ = _wrapped_module_call(  # type: ignore[method-assign]
-            self._model,
             self._id_to_module,
             self._id_to_output_shape,
             self._edges,
+            self._call_counts,
         )
         return self
 
@@ -172,7 +203,8 @@ def trace_module_graph(
 
     Returns:
         tuple: A tuple containing:
-            - id_to_module (dict): Mapping from node id (`str(id(module))`) to the leaf module.
+            - id_to_module (dict): Mapping from node id to the leaf module. A leaf module
+                called more than once gets one entry per call (`f"{id(module)}#{call_index}"`).
             - id_to_output_shape (dict): Mapping from node id to that module's output shape.
             - edges (list): `(producer_node_id, consumer_node_id)` pairs, in call order.
             - input_id (str): The synthetic node id representing the traced input tensor.
@@ -183,8 +215,9 @@ def trace_module_graph(
     id_to_module: dict[str, nn.Module] = {}
     id_to_output_shape: dict[str, tuple[int, ...]] = {}
     edges: list[tuple[str, str]] = []
+    call_counts: dict[int, int] = {}
 
-    with Recorder(model, id_to_module, id_to_output_shape, edges):
+    with Recorder(id_to_module, id_to_output_shape, edges, call_counts):
         model(dummy_input)
 
     return id_to_module, id_to_output_shape, edges, INPUT_NODE_ID

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -1,0 +1,189 @@
+"""Generic module-graph tracing for pytorch model visualization.
+
+Traces a forward pass to recover, for every leaf module actually invoked, which other leaf
+module(s) produced its input(s) - without hardcoding supported layer types and without relying
+on private autograd attributes. Adapted from torchview's (github.com/mert-kurttutan/torchview)
+tensor-subclassing approach, stripped down to only what graph_view needs: one node per leaf
+module (mirroring the leaf definition already used by register_hook), not a node per tensor op.
+"""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from torch import nn
+
+INPUT_NODE_ID = "__input__"
+
+_orig_module_call = nn.Module.__call__
+
+
+class RecorderTensor(torch.Tensor):
+    """A torch.Tensor subclass that propagates which leaf module(s) produced its data.
+
+    Carries a `_producer_ids` set (module ids, `str(id(module))`) through arbitrary tensor
+    operations via `__torch_function__`, so that when a tensor eventually reaches another leaf
+    module call, we know exactly which upstream leaf module(s) it came from - including across
+    ops like `add`/`cat` that merge multiple branches (e.g. residual/skip connections).
+    """
+
+    @classmethod
+    def __torch_function__(
+        cls,
+        func: Any,
+        types: Any,
+        args: tuple = (),
+        kwargs: dict | None = None,
+    ) -> Any:
+        """Intercept every tensor op to propagate producer ids onto the output."""
+        if kwargs is None:
+            kwargs = {}
+
+        producer_ids = _collect_producer_ids(args) | _collect_producer_ids(kwargs)
+
+        out = super().__torch_function__(func, types, args, kwargs)
+
+        if producer_ids:
+            _stamp_producer_ids(out, producer_ids)
+
+        return out
+
+
+def _collect_producer_ids(obj: Any) -> set[str]:
+    """Recursively collect producer ids from any RecorderTensor found inside obj."""
+    ids: set[str] = set()
+    if isinstance(obj, RecorderTensor):
+        ids.update(getattr(obj, "_producer_ids", set()))
+    elif isinstance(obj, torch.Tensor):
+        pass
+    elif isinstance(obj, Mapping):
+        for value in obj.values():
+            ids.update(_collect_producer_ids(value))
+    elif isinstance(obj, list | tuple | set):
+        for value in obj:
+            ids.update(_collect_producer_ids(value))
+    return ids
+
+
+def _stamp_producer_ids(obj: Any, ids: set[str]) -> None:
+    """Recursively stamp producer ids onto any RecorderTensor found inside obj."""
+    if isinstance(obj, RecorderTensor):
+        obj._producer_ids = set(ids)  # noqa: SLF001
+    elif isinstance(obj, torch.Tensor):
+        pass
+    elif isinstance(obj, Mapping):
+        for value in obj.values():
+            _stamp_producer_ids(value, ids)
+    elif isinstance(obj, list | tuple | set):
+        for value in obj:
+            _stamp_producer_ids(value, ids)
+
+
+def _first_tensor_shape(obj: Any) -> tuple[int, ...]:
+    """Recursively find the shape of the first tensor inside obj, or () if there isn't one."""
+    if isinstance(obj, torch.Tensor):
+        return tuple(obj.shape)
+    if isinstance(obj, Mapping):
+        for value in obj.values():
+            shape = _first_tensor_shape(value)
+            if shape:
+                return shape
+        return ()
+    if isinstance(obj, list | tuple):
+        for value in obj:
+            shape = _first_tensor_shape(value)
+            if shape:
+                return shape
+        return ()
+    return ()
+
+
+def _wrapped_module_call(
+    model: nn.Module,
+    id_to_module: dict[str, nn.Module],
+    id_to_output_shape: dict[str, tuple[int, ...]],
+    edges: list[tuple[str, str]],
+) -> Any:
+    """Build the replacement for nn.Module.__call__ used while tracing."""
+
+    def wrapped(mod: nn.Module, *args: Any, **kwargs: Any) -> Any:
+        producer_ids = _collect_producer_ids(args) | _collect_producer_ids(kwargs)
+
+        out = _orig_module_call(mod, *args, **kwargs)
+
+        # Only leaf modules (no children) become graph nodes - containers such as
+        # nn.Sequential or a custom composite block are transparent plumbing, matching the
+        # leaf definition already used by register_hook for layered_view/lenet_view.
+        is_leaf = len(list(mod.children())) == 0
+        if is_leaf and mod is not model:
+            node_id = str(id(mod))
+            id_to_module[node_id] = mod
+            id_to_output_shape[node_id] = _first_tensor_shape(out)
+            for producer_id in producer_ids:
+                edges.append((producer_id, node_id))
+            _stamp_producer_ids(out, {node_id})
+
+        return out
+
+    return wrapped
+
+
+class Recorder:
+    """Context manager that temporarily wraps nn.Module.__call__ to trace leaf-module calls."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        id_to_module: dict[str, nn.Module],
+        id_to_output_shape: dict[str, tuple[int, ...]],
+        edges: list[tuple[str, str]],
+    ) -> None:
+        self._model = model
+        self._id_to_module = id_to_module
+        self._id_to_output_shape = id_to_output_shape
+        self._edges = edges
+
+    def __enter__(self) -> "Recorder":
+        nn.Module.__call__ = _wrapped_module_call(  # type: ignore[method-assign]
+            self._model,
+            self._id_to_module,
+            self._id_to_output_shape,
+            self._edges,
+        )
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
+        nn.Module.__call__ = _orig_module_call  # type: ignore[method-assign]
+
+
+def trace_module_graph(
+    model: nn.Module,
+    input_shape: tuple[int, ...],
+) -> tuple[dict[str, nn.Module], dict[str, tuple[int, ...]], list[tuple[str, str]], str]:
+    """Trace a forward pass to recover the leaf-module call graph.
+
+    Args:
+        model (nn.Module): The model to trace.
+        input_shape (tuple): The shape of the dummy input tensor, including batch dim.
+
+    Returns:
+        tuple: A tuple containing:
+            - id_to_module (dict): Mapping from node id (`str(id(module))`) to the leaf module.
+            - id_to_output_shape (dict): Mapping from node id to that module's output shape.
+            - edges (list): `(producer_node_id, consumer_node_id)` pairs, in call order.
+            - input_id (str): The synthetic node id representing the traced input tensor.
+    """
+    dummy_input = torch.rand(input_shape).as_subclass(RecorderTensor)
+    dummy_input._producer_ids = {INPUT_NODE_ID}  # noqa: SLF001
+
+    id_to_module: dict[str, nn.Module] = {}
+    id_to_output_shape: dict[str, tuple[int, ...]] = {}
+    edges: list[tuple[str, str]] = []
+
+    with Recorder(model, id_to_module, id_to_output_shape, edges):
+        model(dummy_input)
+
+    return id_to_module, id_to_output_shape, edges, INPUT_NODE_ID

--- a/visualtorch/utils/traced_layer.py
+++ b/visualtorch/utils/traced_layer.py
@@ -1,0 +1,22 @@
+"""Traced layer wrapper for graph-style pytorch model visualization."""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass
+
+from torch import nn
+
+
+@dataclass
+class TracedLayer:
+    """A single leaf-module node recovered while tracing a model's forward pass.
+
+    `node_id` must be the same string key used to index this node in the adjacency matrix
+    (see `visualtorch.utils.recorder.trace_module_graph`), not `id()` of this wrapper - otherwise
+    connector drawing in graph.py silently fails to find the node it should connect to.
+    """
+
+    module: nn.Module
+    output_shape: tuple[int, ...]
+    node_id: str


### PR DESCRIPTION
## Summary
- Picks up the board's "investigate torchview" in-progress item. `graph_view` previously only supported `nn.Linear`/`nn.Conv2d` (hardcoded `TARGET_OPS` mapping autograd op class names), detected by walking the autograd backward graph and reading private autograd attributes for shape info. Anything else (BatchNorm, activations, LSTM, attention, residual/skip connections) was invisible or broke the topology.
- Studied torchview's (mert-kurttutan/torchview) approach directly from its source: it subclasses `torch.Tensor` and intercepts every op via `__torch_function__` to trace real data flow instead of post-hoc autograd inspection. Ported a much smaller slice of that mechanism scoped to what `graph_view` actually needs.
- New `visualtorch/utils/recorder.py`: a `RecorderTensor` that propagates "which leaf module(s) produced this data" through arbitrary tensor ops, plus a `Recorder` context manager that patches `nn.Module.__call__` during a traced forward pass. Only **leaf modules** (no children — same definition already used by `register_hook`) become graph nodes; containers are transparent. This gives arbitrary-layer-type support and branching/merge support (a tensor consumed by two producers just gets two incoming edges) for free, with no hardcoded op list and no private-attribute dependency.
- `model_to_adj_matrix` (`layer_utils.py`) now builds its adjacency matrix from this trace, using longest-path-from-source layering (via topological order) instead of the old BFS-from-deepest-autograd-node heuristic, so merge nodes are placed correctly relative to branches that haven't converged yet.
- `graph.py` derives neuron/box counts generically from each layer's already-known output shape instead of sniffing private autograd attributes (`_saved_bias_sym_sizes_opt` etc.), removing `TARGET_OPS` entirely.
- Verified byte-identical rendered output against `main` for every existing Linear/Conv2d test case (image-hash comparison via a temporary git worktree) — this is a pure mechanism swap for currently-supported models, not a visual change.

## Code review follow-up
Ran an independent multi-angle review (different model than the one that wrote this) against the diff, which surfaced 4 real correctness bugs — all fixed in a follow-up commit, each verified by direct reproduction before and after:
- Weight sharing (a leaf module called more than once in one forward pass) crashed with `KeyError` (self-referential edge never resolving in the topological sort). Fixed by giving each call site its own node id.
- A bare leaf module passed directly as the model (e.g. `graph_view(nn.Linear(4,2), ...)`) crashed with `IndexError` — a genuine regression vs. `main`, now fixed.
- A deeper node that also directly consumes the raw input (e.g. the far side of a skip connection around a hidden sub-block) silently lost its input connector; `model_to_adj_matrix` now tracks every direct input consumer regardless of depth.
- Producer-id tracking silently broke when a leaf module's forward escaped the tensor subclass internally (e.g. a numpy round-trip), disconnecting everything downstream with no error. Leaf-module outputs are now force-wrapped back into `RecorderTensor` at the module-call boundary.

## Test plan
- [x] `pytest tests/` — 39/39 passing (up from 30): all pre-existing tests pass unchanged, plus tests for a skip-connection model, a `BatchNorm2d` model, structural adjacency-matrix assertions, and regression tests for the 4 bugs above (confirmed each fails against the pre-fix code and passes after).
- [x] Byte-identical image hash vs `main` for `dense_model`/`conv_model`/`wide_dense_model` (with `ellipsize_after`, `show_neurons=False`), re-verified after the bugfix commit too.
- [x] `pre-commit run --all-files` — all hooks pass

## Known limitations (documented, not fixed here)
- The global `nn.Module.__call__` patch during tracing is not thread-safe (same limitation torchview accepts).
- A leaf module whose forward constructs a brand-new tensor without deriving it from its input at all (ignores its argument entirely) still produces a rootless node — degrades gracefully, strictly better than being invisible as before.