### PR TITLE
Add configurable output-shape labels to layered_view and graph_view

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -245,3 +245,21 @@ def test_model_to_adj_matrix_survives_subclass_escaping_op() -> None:
         "NumpyRoundTrip",
         "Linear",
     ]
+
+
+def test_graph_view_with_show_dimension(dense_model: nn.Module) -> None:
+    """show_dimension=True should print each layer's shape without clipping or crashing."""
+    img = graph_view(dense_model, input_shape=(1, 4), show_dimension=True)
+    assert img is not None
+
+
+def test_graph_view_show_dimension_with_ellipsized_layer(wide_dense_model: nn.Module) -> None:
+    """A wide, ellipsized layer's label should still be placed correctly."""
+    img = graph_view(wide_dense_model, input_shape=(1, 4), show_dimension=True, ellipsize_after=10)
+    assert img is not None
+
+
+def test_graph_view_show_dimension_with_branching(residual_model: nn.Module) -> None:
+    """A column with a skip-connection merge should still get a correctly placed label."""
+    img = graph_view(residual_model, input_shape=(1, 4), show_dimension=True)
+    assert img is not None

--- a/tests/test_layered.py
+++ b/tests/test_layered.py
@@ -163,3 +163,15 @@ def test_layered_view_writes_to_file(sequential_model: nn.Sequential, tmp_path: 
     with Image.open(out_file) as saved_img:
         assert saved_img.size[0] > 0
         assert saved_img.size[1] > 0
+
+
+def test_layered_view_with_show_dimension(sequential_model: nn.Sequential) -> None:
+    """show_dimension=True should print each layer's shape without clipping or crashing."""
+    img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), show_dimension=True)
+    assert img is not None
+
+
+def test_layered_view_show_dimension_with_legend(sequential_model: nn.Sequential) -> None:
+    """show_dimension and legend should be combinable."""
+    img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), show_dimension=True, legend=True)
+    assert img is not None

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -11,11 +11,11 @@ from typing import Any
 import aggdraw
 import numpy as np
 import torch
-from PIL import Image
+from PIL import Image, ImageFont
 
 from .utils.layer_utils import add_input_dummy_layer, model_to_adj_matrix
 from .utils.traced_layer import TracedLayer
-from .utils.utils import Box, Circle, Ellipses, get_keys_by_value
+from .utils.utils import Box, Circle, Ellipses, ImageDraw, get_keys_by_value
 
 
 def graph_view(
@@ -33,6 +33,9 @@ def graph_view(
     ellipsize_after: int = 10,
     show_neurons: bool = True,
     opacity: int = 255,
+    show_dimension: bool = False,
+    font: ImageFont = None,
+    font_color: str | tuple[int, ...] = "black",
 ) -> Image.Image:
     """Generates an architecture visualization for a given linear PyTorch model in a graph style.
 
@@ -56,6 +59,9 @@ def graph_view(
         show_neurons (bool, optional): If True a node for each neuron in supported layers is created (constrained by
             ellipsize_after), else each layer is represented by a node.
         opacity (int, optional): Transparency of the color (0 ~ 255).
+        show_dimension (bool, optional): If True, print each layer's output shape below it.
+        font (PIL.ImageFont, optional): Font used for the shape labels. If None, default font will be used.
+        font_color (str or tuple, optional): Color for the font if used. Can be a string or a tuple (R, G, B, A).
 
     Returns:
         Image.Image: Generated architecture image.
@@ -87,7 +93,7 @@ def graph_view(
 
     current_x = padding  # + input_label_size[0] + text_padding
 
-    layers, layer_y, id_to_node_list_map = _create_architecture(
+    layers, layer_y, id_to_node_list_map, label_info = _create_architecture(
         model_layers,
         current_x,
         show_neurons,
@@ -99,10 +105,23 @@ def graph_view(
         layer_spacing,
     )
 
+    if font is None and show_dimension:
+        font = ImageFont.load_default()
+
+    # Reserve a fixed-height strip below each layer's own content for its shape label,
+    # measured up front so labels never clip the bottom of the canvas.
+    label_row_height = 0
+    if show_dimension:
+        label_row_height = font.getbbox("Ag")[3] + 5
+
     # Generate image
 
-    img_width = len(layers) * node_size + (len(layers) - 1) * layer_spacing + 2 * padding
-    img_height = max(*layer_y) + 2 * padding
+    img_width: float = len(layers) * node_size + (len(layers) - 1) * layer_spacing + 2 * padding
+    img_height = max(*layer_y) + 2 * padding + label_row_height
+
+    if show_dimension:
+        label_info, img_width = _fit_dimension_labels(layers, label_info, font, img_width)
+
     img = Image.new(
         "RGBA",
         (int(ceil(img_width)), int(ceil(img_height))),
@@ -113,11 +132,12 @@ def graph_view(
 
     # y correction (centering)
     for i, layer in enumerate(layers):
-        y_off = (img.height - layer_y[i]) / 2
+        y_off = (img.height - label_row_height - layer_y[i]) / 2
         node: Any
         for node in layer:
             node.y1 += y_off
             node.y2 += y_off
+        label_info[i] = [(label, center_x, y + y_off) for label, center_x, y in label_info[i]]
 
     for start_idx, end_idx in zip(*np.where(adj_matrix > 0), strict=False):
         start_id = next(get_keys_by_value(id_to_num_mapping, start_idx))
@@ -147,10 +167,67 @@ def graph_view(
 
     draw.flush()
 
+    # Print each layer's output shape below its own block of nodes
+    if show_dimension:
+        img = _draw_dimension_labels(img, label_info, font, font_color)
+
     if to_file is not None:
         img.save(to_file)
 
     return img
+
+
+def _fit_dimension_labels(
+    layers: list[list[Any]],
+    label_info: list[list[tuple[str, float, float]]],
+    font: ImageFont,
+    img_width: float,
+) -> tuple[list[list[tuple[str, float, float]]], float]:
+    """Extend the canvas and shift nodes so the outermost labels never clip an edge.
+
+    Extend the canvas and shift nodes right if the outermost labels are wider than their
+    column, so they never clip past the left or right edge of the canvas.
+
+    Returns:
+        tuple: The updated `label_info` and `img_width`.
+    """
+    extra_left = 0.0
+    extra_right = 0.0
+    for column_labels in label_info:
+        for label, center_x, _y in column_labels:
+            label_width = font.getbbox(label)[2]
+            extra_left = max(extra_left, label_width / 2 - center_x)
+            extra_right = max(extra_right, center_x + label_width / 2 - img_width)
+
+    if extra_left > 0:
+        for layer in layers:
+            for node in layer:
+                node.x1 += extra_left
+                node.x2 += extra_left
+        label_info = [
+            [(label, center_x + extra_left, y) for label, center_x, y in column_labels] for column_labels in label_info
+        ]
+        img_width += extra_left
+
+    return label_info, img_width + max(extra_right, 0.0)
+
+
+def _draw_dimension_labels(
+    img: Image.Image,
+    label_info: list[list[tuple[str, float, float]]],
+    font: ImageFont,
+    font_color: str | tuple[int, ...],
+) -> Image.Image:
+    """Draw each layer's output shape centered beneath its own block of nodes."""
+    text_img = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw_text = ImageDraw.Draw(text_img)
+
+    for column_labels in label_info:
+        for label, center_x, y_bottom in column_labels:
+            text_width = font.getbbox(label)[2]
+            draw_text.text((center_x - text_width / 2, y_bottom + 2), label, font=font, fill=font_color)
+
+    return Image.alpha_composite(img, text_img)
 
 
 def _draw_connector(
@@ -201,14 +278,18 @@ def _create_architecture(
     color_map: dict[Any, Any],
     opacity: int,
     layer_spacing: int,
-) -> tuple[list, list, dict]:
+) -> tuple[list, list, dict, list[list[tuple[str, float, float]]]]:
     """Create nodes of architecture for each layers."""
     id_to_node_list_map = {}
     layers = []
     layer_y = []
+    # (label text, x center, y bottom) per layer, grouped by column - a column can hold more
+    # than one layer if multiple leaf modules share the same depth (parallel branches).
+    label_info: list[list[tuple[str, float, float]]] = []
     for layer_list in model_layers:
         current_y = 0
         nodes = []
+        column_labels: list[tuple[str, float, float]] = []
         layer: TracedLayer
         for layer in layer_list:
             is_box, units = _retrieve_isbox_units(layer, show_neurons)
@@ -246,9 +327,11 @@ def _create_architecture(
 
             id_to_node_list_map[layer.node_id] = layer_nodes
             nodes.extend(layer_nodes)
+            column_labels.append((str(layer.output_shape), current_x + node_size / 2, current_y))
             current_y += 2 * node_size
 
         layer_y.append(current_y - node_spacing - 2 * node_size)
         layers.append(nodes)
+        label_info.append(column_labels)
         current_x += node_size + layer_spacing
-    return layers, layer_y, id_to_node_list_map
+    return layers, layer_y, id_to_node_list_map, label_info

--- a/visualtorch/layered.py
+++ b/visualtorch/layered.py
@@ -51,6 +51,7 @@ def layered_view(
     font: ImageFont = None,
     font_color: str | tuple[int, ...] = "black",
     opacity: int = 255,
+    show_dimension: bool = False,
 ) -> PIL.Image:
     """Generate a layered architecture visualization for a given torch model.
 
@@ -80,6 +81,7 @@ def layered_view(
         font (PIL.ImageFont, optional): Font that will be used for the legend. If None, default font will be used.
         font_color (str or tuple, optional): Color for the font if used. Can be a string or a tuple (R, G, B, A).
         opacity (int): Transparency of the color (0 ~ 255).
+        show_dimension (bool, optional): If True, print each layer's output shape below it.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
@@ -91,7 +93,7 @@ def layered_view(
     x_off = -1
 
     img_height = 0
-    max_right = 0
+    max_right: float = 0
 
     if type_ignore is None:
         type_ignore = []
@@ -146,25 +148,75 @@ def layered_view(
         padding,
     )
 
+    if font is None and (show_dimension or legend):
+        font = ImageFont.load_default()
+
+    # Reserve a fixed-height row below the diagram for shape labels, measured up front so
+    # boxes can still be centered within just the diagram area (not the extended canvas),
+    # and so labels never clip or overlap the diagram itself.
+    label_row_height = 0
+    if show_dimension:
+        label_row_height = font.getbbox("Ag")[3] + 5
+        max_right = _fit_dimension_labels(boxes, font, x_off, max_right)
+
     # Generate image
     img_width = max_right + x_off + padding
+    diagram_height = img_height
     img = Image.new(
         "RGBA",
-        (int(ceil(img_width)), int(ceil(img_height))),
+        (int(ceil(img_width)), int(ceil(diagram_height + label_row_height))),
         background_fill,
     )
     draw = aggdraw.Draw(img)
 
-    # x, y correction (centering)
+    _center_and_draw_boxes(draw, boxes, layer_y, diagram_height, x_off, draw_funnel)
+
+    draw.flush()
+
+    # Print each layer's output shape in the reserved row below the diagram
+    if show_dimension:
+        img = _draw_dimension_labels(img, boxes, diagram_height, font, font_color)
+
+    # Create layer color legend
+    if legend:
+        if font is None:
+            font = ImageFont.load_default()
+        img = _draw_legend(
+            img,
+            layer_types,
+            _color_map,
+            font,
+            font_color,
+            draw_volume,
+            shade_step,
+            opacity,
+            spacing,
+            padding,
+            background_fill,
+        )
+
+    if to_file is not None:
+        img.save(to_file)
+
+    return img
+
+
+def _center_and_draw_boxes(
+    draw: aggdraw.Draw,
+    boxes: list[Box],
+    layer_y: list,
+    diagram_height: float,
+    x_off: int,
+    draw_funnel: bool,
+) -> None:
+    """Center each box vertically within the diagram area, then draw boxes and funnels."""
     for i, node in enumerate(boxes):
-        y_off = (img.height - layer_y[i]) / 2
+        y_off = (diagram_height - layer_y[i]) / 2
         node.y1 += y_off
         node.y2 += y_off
 
         node.x1 += x_off
         node.x2 += x_off
-
-    # Draw created boxes
 
     last_box = None
 
@@ -200,74 +252,148 @@ def layered_view(
 
         last_box = box
 
-    draw.flush()
 
-    # Create layer color legend
-    if legend:
-        if font is None:
-            font = ImageFont.load_default()
+def _draw_legend(
+    img: PIL.Image,
+    layer_types: list[type],
+    color_map: dict,
+    font: ImageFont,
+    font_color: str | tuple[int, ...],
+    draw_volume: bool,
+    shade_step: int,
+    opacity: int,
+    spacing: int,
+    padding: int,
+    background_fill: str | tuple[int, ...],
+) -> PIL.Image:
+    """Build and append a color legend, one entry per layer type, below the diagram."""
+    text_height = font.getbbox("Ag")[3]
+    cube_size = text_height
 
-        text_height = font.getbbox("Ag")[3]
-        cube_size = text_height
+    de = 0
+    if draw_volume:
+        de = cube_size // 2
 
-        de = 0
-        if draw_volume:
-            de = cube_size // 2
+    patches = []
 
-        patches = []
+    for layer_type in layer_types:
+        label = layer_type.__name__
+        text_size = font.getbbox(label)
+        label_patch_size = (cube_size + de + spacing + text_size[2], cube_size + de)
+        # this only works if cube_size is bigger than text height
 
-        for layer_type in layer_types:
-            label = layer_type.__name__
-            text_size = font.getbbox(label)
-            label_patch_size = (cube_size + de + spacing + text_size[2], cube_size + de)
-            # this only works if cube_size is bigger than text height
+        img_box = Image.new("RGBA", label_patch_size, background_fill)
+        img_text = Image.new("RGBA", label_patch_size, (0, 0, 0, 0))
+        draw_box = aggdraw.Draw(img_box)
+        draw_text = ImageDraw.Draw(img_text)
 
-            img_box = Image.new("RGBA", label_patch_size, background_fill)
-            img_text = Image.new("RGBA", label_patch_size, (0, 0, 0, 0))
-            draw_box = aggdraw.Draw(img_box)
-            draw_text = ImageDraw.Draw(img_text)
+        box = Box()
+        box.x1 = 0
+        box.x2 = box.x1 + cube_size
+        box.y1 = de
+        box.y2 = box.y1 + cube_size
+        box.de = de
+        box.shade = shade_step
+        box.set_fill(color_map.get(layer_type, {}).get("fill", "#000000"), opacity)
+        box.outline = color_map.get(layer_type, {}).get("outline", "#000000")
+        box.draw(draw_box)
 
-            box = Box()
-            box.x1 = 0
-            box.x2 = box.x1 + cube_size
-            box.y1 = de
-            box.y2 = box.y1 + cube_size
-            box.de = de
-            box.shade = shade_step
-            box.set_fill(_color_map.get(layer_type, {}).get("fill", "#000000"), opacity)
-            box.outline = _color_map.get(layer_type, {}).get("outline", "#000000")
-            box.draw(draw_box)
+        text_x = box.x2 + box.de + spacing
+        text_y = (label_patch_size[1] - text_height) / 2  # 2D center; use text_height and not the current label!
+        draw_text.text((text_x, text_y), label, font=font, fill=font_color)
 
-            text_x = box.x2 + box.de + spacing
-            text_y = (label_patch_size[1] - text_height) / 2  # 2D center; use text_height and not the current label!
-            draw_text.text((text_x, text_y), label, font=font, fill=font_color)
+        draw_box.flush()
+        img_box.paste(img_text, mask=img_text)
+        patches.append(img_box)
 
-            draw_box.flush()
-            img_box.paste(img_text, mask=img_text)
-            patches.append(img_box)
+    legend_image = linear_layout(
+        patches,
+        max_width=img.width,
+        max_height=img.height,
+        padding=padding,
+        spacing=spacing,
+        background_fill=background_fill,
+        horizontal=True,
+    )
+    return vertical_image_concat(img, legend_image, background_fill=background_fill)
 
-        legend_image = linear_layout(
-            patches,
-            max_width=img.width,
-            max_height=img.height,
-            padding=padding,
-            spacing=spacing,
-            background_fill=background_fill,
-            horizontal=True,
-        )
-        img = vertical_image_concat(img, legend_image, background_fill=background_fill)
 
-    if to_file is not None:
-        img.save(to_file)
+def _fit_dimension_labels(
+    boxes: list[Box],
+    font: ImageFont,
+    x_off: int,
+    max_right: float,
+) -> float:
+    """Reposition boxes so shape labels never overlap each other or clip the canvas edges.
 
-    return img
+    Closely packed, thin layers would otherwise smear adjacent shape labels together, so the
+    gap between boxes is widened wherever their labels would collide, and the whole diagram is
+    extended (shifted right, if necessary) so the outermost labels - which can be wider than
+    the box they belong to - never run past the left or right edge.
+
+    Returns:
+        float: The updated `max_right` bound after any widening/shifting.
+    """
+    label_widths = [font.getbbox(str(box.output_shape))[2] for box in boxes]
+
+    shift = 0.0
+    prev_center: float | None = None
+    prev_label_width = 0.0
+    for box, label_width in zip(boxes, label_widths, strict=True):
+        box.x1 += shift
+        box.x2 += shift
+        center = (box.x1 + box.x2) / 2
+        if prev_center is not None:
+            min_gap = (prev_label_width + label_width) / 2 + 5
+            if center - prev_center < min_gap:
+                extra = min_gap - (center - prev_center)
+                box.x1 += extra
+                box.x2 += extra
+                shift += extra
+                center += extra
+        prev_center = center
+        prev_label_width = label_width
+    max_right += shift
+
+    extra_left = 0.0
+    extra_right = 0.0
+    for box, label_width in zip(boxes, label_widths, strict=True):
+        center = (box.x1 + box.x2) / 2
+        extra_left = max(extra_left, label_width / 2 - (center + x_off))
+        extra_right = max(extra_right, (center + label_width / 2) - max_right)
+    if extra_left > 0:
+        for box in boxes:
+            box.x1 += extra_left
+            box.x2 += extra_left
+        max_right += extra_left
+    return max_right + max(extra_right, 0.0)
+
+
+def _draw_dimension_labels(
+    img: PIL.Image,
+    boxes: list[Box],
+    diagram_height: float,
+    font: ImageFont,
+    font_color: str | tuple[int, ...],
+) -> PIL.Image:
+    """Draw each box's output shape centered beneath it, in the reserved label row."""
+    text_img = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw_text = ImageDraw.Draw(text_img)
+
+    for box in boxes:
+        label = str(box.output_shape)
+        text_width = font.getbbox(label)[2]
+        text_x = (box.x1 + box.x2) / 2 - text_width / 2
+        draw_text.text((text_x, diagram_height + 2), label, font=font, fill=font_color)
+
+    return Image.alpha_composite(img, text_img)
 
 
 def _create_architecture(
     layers: OrderedDict[str, Any],
     x_off: int,
     img_height: int,
-    max_right: int,
+    max_right: float,
     type_ignore: list,
     index_ignore: list,
     min_xy: int,
@@ -320,6 +446,7 @@ def _create_architecture(
                 error_msg = f"unsupported orientation: {one_dim_orientation}"
                 raise ValueError(error_msg)
 
+        ori_shape = shape
         shape = shape + (1,) * (4 - len(shape))  # expand 4D.
 
         x = min(max(shape[1] * scale_xy, x), max_xy)
@@ -327,6 +454,7 @@ def _create_architecture(
         z = min(max(int(self_multiply(shape[0:1] + shape[3:]) * scale_z), z), max_z)
 
         box = Box()
+        box.output_shape = tuple(ori_shape)
 
         box.de = 0
         if draw_volume:

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -16,10 +16,10 @@ class Shape:
     """Base class for shapes"""
 
     def __init__(self) -> None:
-        self.x1 = 0
-        self.x2 = 0
-        self.y1 = 0
-        self.y2 = 0
+        self.x1: float = 0
+        self.x2: float = 0
+        self.y1: float = 0
+        self.y2: float = 0
         self._fill = ()
         self._outline = ()
 
@@ -98,6 +98,7 @@ class Box(Shape):
 
     de: int
     shade: int
+    output_shape: tuple[int, ...]
 
     def draw(self, draw: ImageDraw) -> None:
         """Draw box shape."""


### PR DESCRIPTION
## Summary
- Backlog item: "Visualization of output shape". Adds `show_dimension: bool = False` to `layered_view` and `graph_view` (mirrors the existing `legend: bool = False` opt-in convention). `lenet_view` already prints shape unconditionally and is untouched.
- Off by default — every existing call site is unaffected, re-verified byte-identical against `main` for both view functions.
- The real risk flagged before starting this: labels can make a diagram ugly (overlapping/clipped text) on tightly packed layers. Studied visualkeras's `text_callable` system (a much more elaborate version of the same feature) for how it avoids this: measure label extents *before* sizing the canvas, never draw into space that wasn't reserved. Applied a scoped-down version:
  - `layered_view`: labels sit in a reserved row below the diagram; the gap between boxes widens wherever their labels would otherwise overlap (this was visibly broken on a first pass — a 5-layer conv stack smeared all labels together — fixed by widening gaps based on measured label width, then verified visually); the canvas extends so outermost labels never clip an edge.
  - `graph_view`: labels sit below each layer's own block of nodes (handles multiple layers sharing a depth/column, e.g. parallel branches, each getting its own correctly-positioned label); same edge-clipping protection.
- Verified visually (not just "doesn't crash") across: a dense conv stack, a wide ellipsized layer, a classifier model, BatchNorm2d, and a residual/branching model.

## Test plan
- [x] `pytest tests/` — 44/44 passing (up from 39)
- [x] Byte-identical image hash vs `main` for `show_dimension=False` (the default) on both `layered_view` and `graph_view`
- [x] Visual inspection of `show_dimension=True` output for 5+ model shapes (dense stack, conv, wide/ellipsized, classifier, BatchNorm, residual)
- [x] `pre-commit run --all-files` — all hooks pass (including keeping both view functions under the project's cyclomatic-complexity limit, via extracting `_fit_dimension_labels`/`_draw_dimension_labels`/`_draw_legend`/`_center_and_draw_boxes`)