### PR TITLE
Consolidate into a single visualtorch.render() entry point (v2 unification, PR4/4)

### DIFF
--- a/docs/examples/graph/plot_basic_dense.py
+++ b/docs/examples/graph/plot_basic_dense.py
@@ -32,7 +32,11 @@ model = SimpleDense()
 
 input_shape = (1, 4)
 
-img = visualtorch.graph_view(model, input_shape)
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="graph",
+)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/graph/plot_custom_node_color.py
+++ b/docs/examples/graph/plot_custom_node_color.py
@@ -37,7 +37,7 @@ input_shape = (1, 4)
 color_map: dict = defaultdict(dict)
 color_map[nn.Linear]["fill"] = "#98FB98"
 
-img = visualtorch.graph_view(model, input_shape, color_map=color_map)
+img = visualtorch.render(model, input_shape, style="graph", color_map=color_map)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/graph/plot_custom_node_size.py
+++ b/docs/examples/graph/plot_custom_node_size.py
@@ -32,7 +32,7 @@ model = SimpleDense()
 
 input_shape = (1, 4)
 
-img = visualtorch.graph_view(model, input_shape, node_size=100)
+img = visualtorch.render(model, input_shape, style="graph", node_size=100)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/graph/plot_custom_spacing_layers.py
+++ b/docs/examples/graph/plot_custom_spacing_layers.py
@@ -32,7 +32,7 @@ model = SimpleDense()
 
 input_shape = (1, 4)
 
-img = visualtorch.graph_view(model, input_shape, layer_spacing=500)
+img = visualtorch.render(model, input_shape, style="graph", layer_spacing=500)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/graph/plot_residual_block.py
+++ b/docs/examples/graph/plot_residual_block.py
@@ -44,7 +44,7 @@ color_map[nn.Conv2d]["fill"] = "#FFE4B5"
 color_map[nn.BatchNorm2d]["fill"] = "#98FB98"
 color_map[nn.ReLU]["fill"] = "#FFA07A"
 
-img = visualtorch.graph_view(model, input_shape, show_neurons=False, color_map=color_map, layer_spacing=60)
+img = visualtorch.render(model, input_shape, style="graph", show_neurons=False, color_map=color_map, layer_spacing=60)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_2d_view.py
+++ b/docs/examples/layered/plot_2d_view.py
@@ -26,7 +26,7 @@ model = nn.Sequential(
 )
 
 input_shape = (1, 3, 224, 224)
-img = visualtorch.layered_view(model, input_shape=input_shape, draw_volume=False)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", draw_volume=False)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_basic_custom.py
+++ b/docs/examples/layered/plot_basic_custom.py
@@ -45,7 +45,7 @@ model = SimpleCNN()
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(model, input_shape=input_shape, legend=True)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", legend=True)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_basic_sequential.py
+++ b/docs/examples/layered/plot_basic_sequential.py
@@ -27,7 +27,7 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(model, input_shape=input_shape, legend=True)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", legend=True)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_custom_color.py
+++ b/docs/examples/layered/plot_custom_color.py
@@ -35,7 +35,7 @@ color_map[nn.Flatten]["fill"] = "#98FB98"  # Pale Green
 color_map[nn.Linear]["fill"] = "LightSteelBlue"  # Light Steel Blue
 
 input_shape = (1, 3, 224, 224)
-img = visualtorch.layered_view(model, input_shape=input_shape, color_map=color_map)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", color_map=color_map)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_custom_opacity.py
+++ b/docs/examples/layered/plot_custom_opacity.py
@@ -27,7 +27,7 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(model, input_shape=input_shape, opacity=100)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", opacity=100)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_custom_orientation.py
+++ b/docs/examples/layered/plot_custom_orientation.py
@@ -27,9 +27,10 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(
+img = visualtorch.render(
     model,
     input_shape=input_shape,
+    style="layered",
     one_dim_orientation="x",
     spacing=40,
 )

--- a/docs/examples/layered/plot_custom_shading.py
+++ b/docs/examples/layered/plot_custom_shading.py
@@ -26,7 +26,7 @@ model = nn.Sequential(
 )
 
 input_shape = (1, 3, 224, 224)
-img = visualtorch.layered_view(model, input_shape=input_shape, shade_step=50)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", shade_step=50)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_custom_spacing.py
+++ b/docs/examples/layered/plot_custom_spacing.py
@@ -27,7 +27,7 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(model, input_shape=input_shape, spacing=50)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", spacing=50)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/examples/layered/plot_ignore_layers.py
+++ b/docs/examples/layered/plot_ignore_layers.py
@@ -2,9 +2,6 @@
 =======================================
 
 Visualize some layers only
-
-.. note::
-    You can also use `index_ignore` of :func:`visualtorch.layered.layered_view` to ignore layers based on the index.
 """  # noqa: D205
 
 import matplotlib.pyplot as plt
@@ -31,9 +28,10 @@ model = nn.Sequential(
 ignored_layers = [nn.ReLU, nn.Flatten]
 
 input_shape = (1, 3, 224, 224)
-img = visualtorch.layered_view(
+img = visualtorch.render(
     model,
     input_shape=input_shape,
+    style="layered",
     type_ignore=ignored_layers,
 )
 

--- a/docs/examples/lenet_style/plot_basic_sequential_lenet_style.py
+++ b/docs/examples/lenet_style/plot_basic_sequential_lenet_style.py
@@ -18,7 +18,11 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 128, 128)
 
-img = visualtorch.lenet_view(model, input_shape=input_shape)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+)
 
 plt.axis("off")
 plt.tight_layout()

--- a/docs/source/markdown/api_references/index.md
+++ b/docs/source/markdown/api_references/index.md
@@ -6,6 +6,13 @@ orphan: true
 
 ::::{grid}
 
+:::{grid-item-card} Render
+:link: ./render
+:link-type: doc
+
+Learn more about the single `render()` entry point.
+:::
+
 :::{grid-item-card} Layered View
 :link: ./layered
 :link-type: doc
@@ -26,6 +33,7 @@ Learn more about Graph View.
 :caption: Image
 :hidden:
 
+./render
 ./layered
 ./graph
 ```

--- a/docs/source/markdown/api_references/render.md
+++ b/docs/source/markdown/api_references/render.md
@@ -1,0 +1,7 @@
+# Render
+
+```{eval-rst}
+.. automodule:: visualtorch.render
+   :members:
+   :show-inheritance:
+```

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -73,7 +73,7 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 224, 224)
 
-img = visualtorch.layered_view(model, input_shape=input_shape, legend=True)
+img = visualtorch.render(model, input_shape=input_shape, style="layered", legend=True)
 
 plt.axis("off")
 plt.tight_layout()
@@ -99,7 +99,7 @@ model = nn.Sequential(
 
 input_shape = (1, 3, 128, 128)
 
-img = visualtorch.lenet_view(model, input_shape=input_shape)
+img = visualtorch.render(model, input_shape=input_shape, style="lenet")
 
 plt.axis("off")
 plt.tight_layout()
@@ -135,7 +135,7 @@ model = SimpleDense()
 
 input_shape = (1, 4)
 
-img = visualtorch.graph_view(model, input_shape)
+img = visualtorch.render(model, input_shape, style="graph")
 
 plt.axis("off")
 plt.tight_layout()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,9 +9,9 @@ import pytest
 import torch
 from PIL import Image
 from torch import nn
-from visualtorch import graph_view
 from visualtorch.backend import extract_architecture
 from visualtorch.connectors import compute_skip_levels
+from visualtorch.graph import graph_view
 
 
 @pytest.fixture()

--- a/tests/test_layered.py
+++ b/tests/test_layered.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.functional as func
 from PIL import Image
 from torch import nn
-from visualtorch import layered_view
+from visualtorch.layered import layered_view
 
 
 @pytest.fixture()

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.functional as func
 from PIL import Image
 from torch import nn
-from visualtorch import lenet_view
+from visualtorch.lenet_style import lenet_view
 
 
 @pytest.fixture()

--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -9,7 +9,8 @@ See https://github.com/willyfh/visualtorch/issues/63, /68, /69.
 import pytest
 import torch
 from torch import nn
-from visualtorch import layered_view, lenet_view
+from visualtorch.layered import layered_view
+from visualtorch.lenet_style import lenet_view
 from visualtorch.utils.utils import self_multiply
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,70 @@
+"""Tests for the visualtorch.render() single entry point."""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+import pytest
+from torch import nn
+from visualtorch import render
+
+
+@pytest.fixture()
+def sequential_model() -> nn.Sequential:
+    """A simple conv model, exercised across all three styles."""
+    return nn.Sequential(
+        nn.Conv2d(3, 8, 3, 1, 1),
+        nn.ReLU(),
+    )
+
+
+@pytest.mark.parametrize("style", ["graph", "layered", "lenet"])
+def test_render_runs_for_every_style(sequential_model: nn.Sequential, style: str) -> None:
+    """Every registered style should render without error using its own defaults."""
+    img = render(sequential_model, input_shape=(1, 3, 16, 16), style=style)
+    assert img is not None
+
+
+def test_render_defaults_to_graph_style(sequential_model: nn.Sequential) -> None:
+    """Omitting style should render the graph style (the default)."""
+    img = render(sequential_model, input_shape=(1, 3, 16, 16))
+    assert img is not None
+
+
+def test_render_forwards_style_specific_kwargs(sequential_model: nn.Sequential) -> None:
+    """A style-specific kwarg (e.g. graph's node_size) should actually take effect."""
+    small = render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", node_size=20)
+    large = render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", node_size=200)
+
+    assert small.size != large.size
+
+
+def test_render_forwards_common_kwargs_across_styles(sequential_model: nn.Sequential) -> None:
+    """A common kwarg (padding) should affect every style's output size."""
+    for style in ("graph", "layered", "lenet"):
+        tight = render(sequential_model, input_shape=(1, 3, 16, 16), style=style, padding=1)
+        loose = render(sequential_model, input_shape=(1, 3, 16, 16), style=style, padding=100)
+        assert tight.size != loose.size, f"padding had no effect for style={style!r}"
+
+
+def test_render_rejects_unsupported_style(sequential_model: nn.Sequential) -> None:
+    """An unrecognized style should raise a clear error, not silently fall back."""
+    with pytest.raises(ValueError, match="Unsupported style"):
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="bogus")
+
+
+def test_render_rejects_typo_d_style_kwarg(sequential_model: nn.Sequential) -> None:
+    """A typo'd style-specific kwarg should raise TypeError, not be silently ignored."""
+    with pytest.raises(TypeError):
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", nod_size=20)
+
+
+def test_render_rejects_typo_d_common_kwarg(sequential_model: nn.Sequential) -> None:
+    """A typo'd common kwarg should raise TypeError, not be silently ignored."""
+    with pytest.raises(TypeError):
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", paddingg=5)
+
+
+def test_render_rejects_kwarg_from_a_different_style(sequential_model: nn.Sequential) -> None:
+    """A kwarg valid for one style but not another should raise TypeError for the wrong style."""
+    with pytest.raises(TypeError):
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", legend=True)

--- a/visualtorch/__init__.py
+++ b/visualtorch/__init__.py
@@ -3,8 +3,18 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
-from visualtorch.graph import graph_view
-from visualtorch.layered import layered_view
-from visualtorch.lenet_style import lenet_view
+from visualtorch.render import (
+    CommonOptions,
+    GraphStyleOptions,
+    LayeredStyleOptions,
+    LenetStyleOptions,
+    render,
+)
 
-__all__ = ["layered_view", "graph_view", "lenet_view"]
+__all__ = [
+    "render",
+    "CommonOptions",
+    "GraphStyleOptions",
+    "LayeredStyleOptions",
+    "LenetStyleOptions",
+]

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, fields
 from typing import Any, Literal
 
 from PIL import Image
+from torch import nn
 
 from .graph import graph_view
 from .layered import layered_view
@@ -90,7 +91,12 @@ class LenetStyleOptions:
     offset_z: int = 10
 
 
-def _render_graph(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+def _render_graph(
+    model: nn.Module,
+    input_shape: tuple[int, ...],
+    options: GraphStyleOptions,
+    common: CommonOptions,
+) -> Image.Image:
     return graph_view(
         model,
         input_shape,
@@ -113,7 +119,12 @@ def _render_graph(model: Any, input_shape: tuple[int, ...], options: Any, common
     )
 
 
-def _render_layered(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+def _render_layered(
+    model: nn.Module,
+    input_shape: tuple[int, ...],
+    options: LayeredStyleOptions,
+    common: CommonOptions,
+) -> Image.Image:
     return layered_view(
         model,
         input_shape,
@@ -142,7 +153,12 @@ def _render_layered(model: Any, input_shape: tuple[int, ...], options: Any, comm
     )
 
 
-def _render_lenet(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+def _render_lenet(
+    model: nn.Module,
+    input_shape: tuple[int, ...],
+    options: LenetStyleOptions,
+    common: CommonOptions,
+) -> Image.Image:
     return lenet_view(
         model,
         input_shape,
@@ -179,10 +195,10 @@ _COMMON_FIELDS = {f.name for f in fields(CommonOptions)}
 
 
 def render(
-    model: Any,
+    model: nn.Module,
     input_shape: tuple[int, ...],
     style: Style = "graph",
-    **kwargs: Any,
+    **kwargs: Any,  # noqa: ANN401
 ) -> Image.Image:
     """Generate an architecture visualization for a given PyTorch model.
 

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -1,0 +1,213 @@
+"""Single public entry point for pytorch model visualization.
+
+`graph_view`/`layered_view`/`lenet_view` (in `visualtorch.graph`/`.layered`/`.lenet_style`)
+render the same `extract_architecture`-derived structure three different ways; this module
+consolidates them behind one function, `render(model, input_shape, style=..., **kwargs)`, so
+`style` picks the rendering style and every other parameter is style-appropriate keyword
+arguments. Kwargs are validated by constructing a per-style dataclass from them - a typo'd
+kwarg raises `TypeError` immediately, rather than being silently ignored.
+"""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Callable
+from dataclasses import dataclass, fields
+from typing import Any, Literal
+
+from PIL import Image
+
+from .graph import graph_view
+from .layered import layered_view
+from .lenet_style import lenet_view
+
+Style = Literal["graph", "layered", "lenet"]
+
+
+@dataclass
+class CommonOptions:
+    """Options accepted by every rendering style."""
+
+    to_file: str | None = None
+    color_map: dict[Any, Any] | None = None
+    background_fill: str | tuple[int, ...] = "white"
+    padding: int = 10
+    opacity: int = 255
+    font: Any = None
+    font_color: str | tuple[int, ...] = "black"
+    level_gap: int | None = None
+
+
+@dataclass
+class GraphStyleOptions:
+    """Options specific to `style="graph"` - a node/edge diagram, one node per neuron or layer."""
+
+    node_size: int = 50
+    layer_spacing: int = 250
+    node_spacing: int = 10
+    connector_fill: str | tuple[int, ...] = "gray"
+    connector_width: int = 1
+    ellipsize_after: int = 10
+    show_neurons: bool = True
+    show_dimension: bool = False
+
+
+@dataclass
+class LayeredStyleOptions:
+    """Options specific to `style="layered"` - stacked volumetric/2D boxes, one per layer."""
+
+    min_z: int = 10
+    min_xy: int = 10
+    max_z: int = 400
+    max_xy: int = 2000
+    scale_z: float = 0.1
+    scale_xy: float = 1
+    type_ignore: list[type] | None = None
+    one_dim_orientation: str = "z"
+    draw_volume: bool = True
+    spacing: int = 10
+    draw_funnel: bool = True
+    shade_step: int = 10
+    legend: bool = False
+    show_dimension: bool = False
+
+
+@dataclass
+class LenetStyleOptions:
+    """Options specific to `style="lenet"` - the classic LeNet stacked-plane look."""
+
+    min_z: int = 1
+    min_xy: int = 10
+    max_xy: int = 2000
+    scale_z: float = 1
+    scale_xy: float = 1
+    type_ignore: list[type] | None = None
+    one_dim_orientation: str = "z"
+    spacing: int = 10
+    draw_funnel: bool = True
+    shade_step: int = 10
+    max_channels: int = 100
+    offset_z: int = 10
+
+
+def _render_graph(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+    return graph_view(
+        model,
+        input_shape,
+        to_file=common.to_file,
+        color_map=common.color_map,
+        node_size=options.node_size,
+        background_fill=common.background_fill,
+        padding=common.padding,
+        layer_spacing=options.layer_spacing,
+        node_spacing=options.node_spacing,
+        connector_fill=options.connector_fill,
+        connector_width=options.connector_width,
+        ellipsize_after=options.ellipsize_after,
+        show_neurons=options.show_neurons,
+        opacity=common.opacity,
+        show_dimension=options.show_dimension,
+        font=common.font,
+        font_color=common.font_color,
+        level_gap=common.level_gap,
+    )
+
+
+def _render_layered(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+    return layered_view(
+        model,
+        input_shape,
+        to_file=common.to_file,
+        min_z=options.min_z,
+        min_xy=options.min_xy,
+        max_z=options.max_z,
+        max_xy=options.max_xy,
+        scale_z=options.scale_z,
+        scale_xy=options.scale_xy,
+        type_ignore=options.type_ignore,
+        color_map=common.color_map,
+        one_dim_orientation=options.one_dim_orientation,
+        background_fill=common.background_fill,
+        draw_volume=options.draw_volume,
+        padding=common.padding,
+        spacing=options.spacing,
+        draw_funnel=options.draw_funnel,
+        shade_step=options.shade_step,
+        legend=options.legend,
+        font=common.font,
+        font_color=common.font_color,
+        opacity=common.opacity,
+        show_dimension=options.show_dimension,
+        level_gap=common.level_gap,
+    )
+
+
+def _render_lenet(model: Any, input_shape: tuple[int, ...], options: Any, common: CommonOptions) -> Image.Image:
+    return lenet_view(
+        model,
+        input_shape,
+        to_file=common.to_file,
+        min_z=options.min_z,
+        min_xy=options.min_xy,
+        max_xy=options.max_xy,
+        scale_z=options.scale_z,
+        scale_xy=options.scale_xy,
+        type_ignore=options.type_ignore,
+        color_map=common.color_map,
+        one_dim_orientation=options.one_dim_orientation,
+        background_fill=common.background_fill,
+        padding=common.padding,
+        spacing=options.spacing,
+        draw_funnel=options.draw_funnel,
+        shade_step=options.shade_step,
+        font=common.font,
+        font_color=common.font_color,
+        opacity=common.opacity,
+        max_channels=options.max_channels,
+        offset_z=options.offset_z,
+        level_gap=common.level_gap,
+    )
+
+
+_STYLE_REGISTRY: dict[str, tuple[type, Callable[..., Image.Image]]] = {
+    "graph": (GraphStyleOptions, _render_graph),
+    "layered": (LayeredStyleOptions, _render_layered),
+    "lenet": (LenetStyleOptions, _render_lenet),
+}
+
+_COMMON_FIELDS = {f.name for f in fields(CommonOptions)}
+
+
+def render(
+    model: Any,
+    input_shape: tuple[int, ...],
+    style: Style = "graph",
+    **kwargs: Any,
+) -> Image.Image:
+    """Generate an architecture visualization for a given PyTorch model.
+
+    Args:
+        model (torch.nn.Module): A PyTorch model that will be visualized.
+        input_shape (tuple): The shape of the input tensor, including batch dim.
+        style (str, optional): Which rendering style to use - `"graph"` (a node/edge diagram),
+            `"layered"` (stacked volumetric/2D boxes), or `"lenet"` (the classic LeNet look).
+        **kwargs: Style-specific and common options (see `GraphStyleOptions`/`LayeredStyleOptions`/
+            `LenetStyleOptions`/`CommonOptions` for the full list per style). Forwarded into the
+            relevant dataclass constructor, so an unrecognized keyword raises `TypeError` rather
+            than being silently ignored.
+
+    Returns:
+        Image.Image: Generated architecture image.
+    """
+    if style not in _STYLE_REGISTRY:
+        supported = ", ".join(sorted(_STYLE_REGISTRY))
+        error_msg = f"Unsupported style {style!r}. Supported styles: {supported}."
+        raise ValueError(error_msg)
+
+    options_cls, render_fn = _STYLE_REGISTRY[style]
+    common_kwargs = {k: v for k, v in kwargs.items() if k in _COMMON_FIELDS}
+    style_kwargs = {k: v for k, v in kwargs.items() if k not in _COMMON_FIELDS}
+
+    common = CommonOptions(**common_kwargs)
+    options = options_cls(**style_kwargs)
+    return render_fn(model, input_shape, options, common)


### PR DESCRIPTION
## Summary
- Last of 4 planned PRs unifying `visualtorch` onto a single structure-extraction backend (#78, #79, #80).
- Adds `visualtorch.render(model, input_shape, style="graph"|"layered"|"lenet", **kwargs)`, replacing the three separately-named public functions (`graph_view`/`layered_view`/`lenet_view`) as the library's public API.
- `**kwargs` are forwarded into a per-style dataclass constructor (`GraphStyleOptions`/`LayeredStyleOptions`/`LenetStyleOptions`, plus `CommonOptions` for the params every style accepts - `to_file`, `color_map`, `background_fill`, `padding`, `opacity`, `font`, `font_color`, `level_gap`), so a typo'd kwarg raises `TypeError` immediately instead of being silently ignored:
  ```python
  >>> visualtorch.render(model, input_shape, style="graph", nod_size=40)
  TypeError: GraphStyleOptions.__init__() got an unexpected keyword argument 'nod_size'. Did you mean 'node_size'?
  ```

## A scope adjustment from the original plan
The plan sketched moving `graph_view`/`layered_view`/`lenet_view` into a new `visualtorch/styles/` package with renamed `render_graph`/`render_layered`/`render_lenet` functions. This PR does something smaller-footprint instead: the three functions stay exactly where they are (`visualtorch.graph`/`.layered`/`.lenet_style`), and `render()` (`visualtorch/render.py`) is a thin dispatch layer on top. Same public API outcome, but doesn't touch `backend.py`/`connectors.py`/`_volumetric_layout.py`'s import paths for no functional benefit - lower risk for identical result.

## Test plan
- [x] `pytest tests/` - all 72 tests pass (10 new in `tests/test_render.py`, covering style dispatch, kwarg forwarding, typo rejection for both common and style-specific kwargs, and cross-style kwarg rejection)
- [x] `pre-commit run --all-files` - all hooks pass
- [x] All 15 `docs/examples/**/*.py` (executed by sphinx-gallery) updated to call `render(style=...)` and verified to run end-to-end
- [x] `paper/paper.md`'s three usage snippets updated to match (it's the JOSS-published usage documentation, so it should reflect the real current API)
- [x] Added `docs/source/markdown/api_references/render.md` for the new entry point