### PR TITLE
Fix funnel lines disappearing in layered_view/lenet_view on real CNNs

### DIFF
--- a/docs/examples/graph/plot_residual_block.py
+++ b/docs/examples/graph/plot_residual_block.py
@@ -5,6 +5,13 @@ Visualization of a classic ResNet-style residual block: Conv2d + BatchNorm2d, tw
 plain identity shortcut around them and a final ReLU.
 
 Conv2d is orange, BatchNorm2d is green, and ReLU is salmon.
+
+``show_neurons=False`` is used deliberately here, not just as a default: with it on, graph_view
+draws a fully-connected mesh between every pair of adjacent layers' neuron circles, which is
+accurate for a genuinely dense layer (e.g. Linear) but misleading for a convolutional one - a
+Conv2d's real connectivity is local and shared across spatial positions, not "every input
+channel wired to every output channel." With ``show_neurons=False``, each layer draws as a
+single box instead, which is the more honest representation for a conv-heavy model like this.
 """  # noqa: D205
 
 from collections import defaultdict

--- a/docs/examples/graph/plot_residual_block.py
+++ b/docs/examples/graph/plot_residual_block.py
@@ -1,17 +1,17 @@
-"""Residual Block
+"""Hiding Individual Neurons
 =======================================
 
-Visualization of a classic ResNet-style residual block: Conv2d + BatchNorm2d, twice, with a
-plain identity shortcut around them and a final ReLU.
+By default, ``graph_view`` draws a fully-connected mesh between every pair of adjacent layers'
+neuron circles. That's accurate for a genuinely dense layer (e.g. Linear), but misleading for a
+convolutional one - a Conv2d's real connectivity is local and shared across spatial positions,
+not "every input channel wired to every output channel." Setting ``show_neurons=False`` draws
+each layer as a single box instead, which is the more honest representation for a conv-heavy
+model.
 
-Conv2d is orange, BatchNorm2d is green, and ReLU is salmon.
-
-``show_neurons=False`` is used deliberately here, not just as a default: with it on, graph_view
-draws a fully-connected mesh between every pair of adjacent layers' neuron circles, which is
-accurate for a genuinely dense layer (e.g. Linear) but misleading for a convolutional one - a
-Conv2d's real connectivity is local and shared across spatial positions, not "every input
-channel wired to every output channel." With ``show_neurons=False``, each layer draws as a
-single box instead, which is the more honest representation for a conv-heavy model like this.
+The model used here is a classic ResNet-style residual block (Conv2d + BatchNorm2d, twice, with
+a plain identity shortcut and a final ReLU) - conv-heavy and branching, a good stress test for
+both this setting and graph_view's skip-connection routing. Conv2d is orange, BatchNorm2d is
+green, and ReLU is salmon.
 """  # noqa: D205
 
 from collections import defaultdict

--- a/docs/examples/layered/plot_residual_block_layered.py
+++ b/docs/examples/layered/plot_residual_block_layered.py
@@ -1,0 +1,54 @@
+"""Residual Block
+=======================================
+
+Visualization of a classic ResNet-style residual block: Conv2d + BatchNorm2d, twice, with a
+plain identity shortcut around them and a final ReLU.
+
+Conv2d is orange, BatchNorm2d is green, and ReLU is salmon. The skip connection is routed
+above the diagram as a thin line, rather than as a funnel - a funnel implies a continuous
+volume flowing between two layers, which a shortcut connection isn't.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A classic ResNet-style block with a plain identity shortcut."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass, with a skip connection around conv1/bn1/relu/conv2/bn2."""
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return self.relu(out)
+
+
+model = ResidualBlock(channels=8)
+
+input_shape = (1, 8, 16, 16)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#FFE4B5"
+color_map[nn.BatchNorm2d]["fill"] = "#98FB98"
+color_map[nn.ReLU]["fill"] = "#FFA07A"
+
+img = visualtorch.render(model, input_shape, style="layered", color_map=color_map, legend=True)
+
+plt.axis("off")
+plt.tight_layout()
+plt.imshow(img)
+plt.show()

--- a/docs/examples/lenet_style/plot_residual_block_lenet_style.py
+++ b/docs/examples/lenet_style/plot_residual_block_lenet_style.py
@@ -1,0 +1,54 @@
+"""Residual Block
+=======================================
+
+Visualization of a classic ResNet-style residual block: Conv2d + BatchNorm2d, twice, with a
+plain identity shortcut around them and a final ReLU.
+
+Conv2d is orange, BatchNorm2d is green, and ReLU is salmon. The skip connection is routed
+above the diagram as a thin line, rather than as a funnel - a funnel implies a continuous
+volume flowing between two layers, which a shortcut connection isn't.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A classic ResNet-style block with a plain identity shortcut."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass, with a skip connection around conv1/bn1/relu/conv2/bn2."""
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return self.relu(out)
+
+
+model = ResidualBlock(channels=8)
+
+input_shape = (1, 8, 16, 16)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#FFE4B5"
+color_map[nn.BatchNorm2d]["fill"] = "#98FB98"
+color_map[nn.ReLU]["fill"] = "#FFA07A"
+
+img = visualtorch.render(model, input_shape, style="lenet", color_map=color_map)
+
+plt.axis("off")
+plt.tight_layout()
+plt.imshow(img)
+plt.show()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import matplotlib as mpl
 from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
 # Define the path to your module using Path
@@ -19,6 +20,15 @@ module_path = Path(__file__).parent.parent / "src"
 
 # Insert the path to sys.path
 sys.path.insert(0, str(module_path.resolve()))
+
+# Sphinx-Gallery captures each example's figure via matplotlib's savefig, at whatever DPI is
+# active during the doc build - matplotlib's own default (100) downscales anything larger than
+# 640x480 (the default figure size in inches times that DPI), which visibly blurs the thin
+# connector lines and small shape labels in the larger/more detailed generated diagrams. 300 DPI
+# matches standard print/publication figure resolution, since these diagrams are meant to be
+# usable directly in papers, not just viewed on a docs page.
+mpl.rcParams["savefig.dpi"] = 300
+mpl.rcParams["figure.dpi"] = 300
 
 project = "VisualTorch"
 copyright = "2024, Willy Fitra Hendria"  # noqa: A001

--- a/tests/test_layered.py
+++ b/tests/test_layered.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 import torch.nn.functional as func
@@ -339,3 +340,59 @@ def test_layered_view_deep_repeated_residual_blocks_stays_reasonably_sized() -> 
     img_6_blocks = layered_view(DeepModel(4, 6), input_shape=(1, 4, 8, 8))
 
     assert img_2_blocks.size[1] == img_6_blocks.size[1]
+
+
+def _non_background_pixel_count(img: Image.Image) -> int:
+    return int((np.array(img.convert("RGB")) != 255).any(axis=2).sum())
+
+
+def test_layered_view_funnels_survive_large_de_differences_between_layers() -> None:
+    """A funnel between two layers with very different 3D depth (`de`) must stay visible.
+
+    Regression test for a real bug: drawing every connector first and every box second (instead
+    of interleaving them column by column) let each box's opaque fill blot out large parts of
+    its own incoming funnel whenever neighboring layers have a very different `de` - which
+    barely showed on the small, near-constant-`de` models used to verify the layered_view
+    rewrite, but was highly visible on a real CNN (found by the user manually comparing
+    ReadTheDocs' `plot_basic_custom` example before/after the rewrite). Canvas *size* alone
+    doesn't catch this class of bug (box positions are unaffected, only which pixels get
+    painted), so this asserts on rendered content instead.
+    """
+
+    class SimpleCNN(nn.Module):
+        """The exact model from docs/examples/layered/plot_basic_custom.py."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+            self.conv2 = nn.Conv2d(16, 32, kernel_size=3, padding=1)
+            self.conv3 = nn.Conv2d(32, 64, kernel_size=3, padding=1)
+            self.fc1 = nn.Linear(64 * 28 * 28, 128)
+            self.fc2 = nn.Linear(128, 10)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Forward pass with three shrinking conv/pool stages."""
+            x = self.conv1(x)
+            x = func.relu(x)
+            x = func.max_pool2d(x, 2, 2)
+            x = self.conv2(x)
+            x = func.relu(x)
+            x = func.max_pool2d(x, 2, 2)
+            x = self.conv3(x)
+            x = func.relu(x)
+            x = func.max_pool2d(x, 2, 2)
+            x = x.view(x.size(0), -1)
+            x = self.fc1(x)
+            x = func.relu(x)
+            return self.fc2(x)
+
+    img = layered_view(SimpleCNN(), input_shape=(1, 3, 224, 224), legend=True)
+
+    # Locked in from the current (fixed) implementation - confirmed pixel-identical to
+    # pre-rewrite main (1ee630e) via a git-worktree comparison for this exact model. The buggy
+    # intermediate version rendered thousands fewer non-background pixels here (missing funnel
+    # segments), so a wide but real tolerance still catches a regression of that class.
+    assert img.size == (153, 336)
+    non_bg = _non_background_pixel_count(img)
+    error_msg = f"non-background pixel count {non_bg} outside expected range - funnel likely broken"
+    assert 21000 <= non_bg <= 24000, error_msg

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 import torch.nn.functional as func
@@ -246,3 +247,28 @@ def test_lenet_view_residual_model_routes_above_diagram(residual_model: nn.Modul
     img_without_skip = lenet_view(PlainChain(channels=4), input_shape=(1, 4, 8, 8))
 
     assert img_with_skip.size[1] > img_without_skip.size[1]
+
+
+def test_lenet_view_funnels_survive_large_de_differences_between_layers() -> None:
+    """A funnel between two layers with very different depth/spread must stay visible.
+
+    Regression test for the same class of bug fixed in layered_view: drawing every connector
+    first and every box second (instead of interleaving them column by column) let each box's
+    opaque fill blot out large parts of its own incoming funnel whenever neighboring layers have
+    a very different `de`/`offset_z` spread.
+    """
+    model = nn.Sequential(
+        nn.Conv2d(3, 8, kernel_size=3, padding=1),
+        nn.MaxPool2d(2, 2),
+        nn.Conv2d(8, 16, kernel_size=3, padding=1),
+        nn.MaxPool2d(2, 2),
+        nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    )
+
+    img = lenet_view(model, input_shape=(1, 3, 128, 128))
+
+    # Locked in from the current (fixed) implementation.
+    assert img.size == (1348, 558)
+    non_bg = int((np.array(img.convert("RGB")) != 255).any(axis=2).sum())
+    error_msg = f"non-background pixel count {non_bg} outside expected range - funnel likely broken"
+    assert 110000 <= non_bg <= 145000, error_msg

--- a/visualtorch/layered.py
+++ b/visualtorch/layered.py
@@ -175,20 +175,8 @@ def layered_view(
 
     _apply_centering(column_layout, top_margin_for_skips, column_layout.diagram_height)
 
-    _draw_connectors(
-        draw,
-        architecture,
-        column_layout,
-        edge_to_level,
-        num_levels,
-        padding,
-        resolved_level_gap,
-        draw_funnel,
-    )
-
-    for column in column_layout.boxes_by_column:
-        for box in column:
-            box.draw(draw)
+    _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
+    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap)
 
     draw.flush()
 
@@ -309,7 +297,43 @@ def _draw_funnel(draw: aggdraw.Draw, start_box: VolumetricBox, end_box: Volumetr
     draw.line([start_box.x2, start_box.y1, end_box.x1, end_box.y1], pen)
 
 
-def _draw_connectors(
+def _draw_funnels_and_boxes(
+    draw: aggdraw.Draw,
+    architecture: Architecture,
+    column_layout: ColumnLayout,
+    edge_to_level: dict[tuple[str, str], int],
+    draw_funnel_flag: bool,
+) -> None:
+    """Draw each column's incoming funnels, then that column's own boxes, column by column.
+
+    This interleaving matters: a funnel is drawn *before* the box it points to (so the box's own
+    fill covers the funnel's far end, matching a real vanishing-point taper) but *after* the
+    column before it (so the funnel's near end isn't hidden by a box that's about to be
+    re-covered). Drawing every connector first and every box second - simpler, but wrong -
+    would let each box's fill blot out large parts of its own incoming funnel whenever
+    neighboring layers have a very different `de` (3D depth), which is the common case for a
+    real CNN (channel/spatial size changes a lot layer to layer).
+    """
+    if draw_funnel_flag:
+        incoming_funnels: dict[str, list[str]] = {}
+        for start_id, end_id in architecture.edges():
+            if edge_to_level.get((start_id, end_id)) is None and end_id in column_layout.id_to_box:
+                incoming_funnels.setdefault(end_id, []).append(start_id)
+        layer_id_by_box: dict[int, str] = {id(box): layer_id for layer_id, box in column_layout.id_to_box.items()}
+
+    for column in column_layout.boxes_by_column:
+        if draw_funnel_flag:
+            for box in column:
+                layer_id = layer_id_by_box[id(box)]
+                for start_id in incoming_funnels.get(layer_id, []):
+                    if start_id in column_layout.id_to_box:
+                        _draw_funnel(draw, column_layout.id_to_box[start_id], box)
+
+        for box in column:
+            box.draw(draw)
+
+
+def _draw_skip_connectors(
     draw: aggdraw.Draw,
     architecture: Architecture,
     column_layout: ColumnLayout,
@@ -317,36 +341,33 @@ def _draw_connectors(
     num_levels: int,
     padding: int,
     resolved_level_gap: int,
-    draw_funnel_flag: bool,
 ) -> None:
-    """Draw every connector: a funnel for adjacent columns, a routed line for skips.
+    """Draw every skip-connection edge, routed above the diagram.
 
-    Skip connections (spanning more than one column) always draw, regardless of `draw_funnel_flag`
-    - a funnel implies a continuous volume flowing between two layers, which a skip connection
-    isn't, and it should never become invisible just because funnels are toggled off.
+    Drawn in a separate pass after every funnel and box, so a routed line is always visible on
+    top rather than potentially hidden under a box it happens to cross over. Always drawn
+    regardless of `draw_funnel` - a funnel implies a continuous volume flowing between two
+    layers, which a skip connection isn't, and it should never become invisible just because
+    funnels are toggled off.
     """
     for start_id, end_id in architecture.edges():
-        if start_id not in column_layout.id_to_box or end_id not in column_layout.id_to_box:
-            continue  # the synthetic input node has no box in this style
+        level = edge_to_level.get((start_id, end_id))
+        if level is None or start_id not in column_layout.id_to_box or end_id not in column_layout.id_to_box:
+            continue
 
         start_box = column_layout.id_to_box[start_id]
         end_box = column_layout.id_to_box[end_id]
-        level = edge_to_level.get((start_id, end_id))
-
-        if level is not None:
-            detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
-            draw_connector(
-                draw,
-                start_box.x2,
-                (start_box.y1 + start_box.y2) / 2,
-                end_box.x1,
-                (end_box.y1 + end_box.y2) / 2,
-                color=end_box.outline,
-                width=1,
-                detour_y=detour_y,
-            )
-        elif draw_funnel_flag:
-            _draw_funnel(draw, start_box, end_box)
+        detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
+        draw_connector(
+            draw,
+            start_box.x2,
+            (start_box.y1 + start_box.y2) / 2,
+            end_box.x1,
+            (end_box.y1 + end_box.y2) / 2,
+            color=end_box.outline,
+            width=1,
+            detour_y=detour_y,
+        )
 
 
 def _draw_legend(

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -157,20 +157,8 @@ def lenet_view(
 
     _apply_centering(column_layout, top_margin_for_skips + spread_margin / 2)
 
-    _draw_connectors(
-        draw,
-        architecture,
-        column_layout,
-        edge_to_level,
-        num_levels,
-        padding,
-        resolved_level_gap,
-        draw_funnel,
-    )
-
-    for column in column_layout.boxes_by_column:
-        for box in column:
-            box.draw(draw)
+    _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
+    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap)
 
     draw.flush()
 
@@ -288,7 +276,41 @@ def _draw_stacked_funnel(draw: aggdraw.Draw, start_box: VolumetricBox, end_box: 
     draw.line([start_box.x2 + start_off, start_box.y2 + start_off, end_box.x1 + end_off, end_box.y2 + end_off], pen)
 
 
-def _draw_connectors(
+def _draw_funnels_and_boxes(
+    draw: aggdraw.Draw,
+    architecture: Architecture,
+    column_layout: ColumnLayout,
+    edge_to_level: dict[tuple[str, str], int],
+    draw_funnel_flag: bool,
+) -> None:
+    """Draw each column's incoming funnels, then that column's own boxes, column by column.
+
+    This interleaving matters: a funnel is drawn *before* the box it points to (so the box's own
+    fill covers the funnel's far end) but *after* the column before it. Drawing every connector
+    first and every box second - simpler, but wrong - would let each box's fill blot out large
+    parts of its own incoming funnel whenever neighboring layers have a very different `de`/
+    `offset_z` spread, which is the common case for a real CNN.
+    """
+    if draw_funnel_flag:
+        incoming_funnels: dict[str, list[str]] = {}
+        for start_id, end_id in architecture.edges():
+            if edge_to_level.get((start_id, end_id)) is None and end_id in column_layout.id_to_box:
+                incoming_funnels.setdefault(end_id, []).append(start_id)
+        layer_id_by_box: dict[int, str] = {id(box): layer_id for layer_id, box in column_layout.id_to_box.items()}
+
+    for column in column_layout.boxes_by_column:
+        if draw_funnel_flag:
+            for box in column:
+                layer_id = layer_id_by_box[id(box)]
+                for start_id in incoming_funnels.get(layer_id, []):
+                    if start_id in column_layout.id_to_box:
+                        _draw_stacked_funnel(draw, column_layout.id_to_box[start_id], box)
+
+        for box in column:
+            box.draw(draw)
+
+
+def _draw_skip_connectors(
     draw: aggdraw.Draw,
     architecture: Architecture,
     column_layout: ColumnLayout,
@@ -296,37 +318,33 @@ def _draw_connectors(
     num_levels: int,
     padding: int,
     resolved_level_gap: int,
-    draw_funnel_flag: bool,
 ) -> None:
-    """Draw every connector: a funnel for adjacent columns, a routed line for skips.
+    """Draw every skip-connection edge, routed above the diagram.
 
-    Skip connections (spanning more than one column) always draw, regardless of
-    `draw_funnel_flag` - a funnel implies a continuous volume flowing between two layers, which
-    a skip connection isn't, and it should never become invisible just because funnels are
-    toggled off.
+    Drawn in a separate pass after every funnel and box, so a routed line is always visible on
+    top rather than potentially hidden under a box it happens to cross over. Always drawn
+    regardless of `draw_funnel` - a funnel implies a continuous volume flowing between two
+    layers, which a skip connection isn't, and it should never become invisible just because
+    funnels are toggled off.
     """
     for start_id, end_id in architecture.edges():
-        if start_id not in column_layout.id_to_box or end_id not in column_layout.id_to_box:
+        level = edge_to_level.get((start_id, end_id))
+        if level is None or start_id not in column_layout.id_to_box or end_id not in column_layout.id_to_box:
             continue
 
         start_box = column_layout.id_to_box[start_id]
         end_box = column_layout.id_to_box[end_id]
-        level = edge_to_level.get((start_id, end_id))
-
-        if level is not None:
-            detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
-            draw_connector(
-                draw,
-                start_box.x2,
-                (start_box.y1 + start_box.y2) / 2,
-                end_box.x1,
-                (end_box.y1 + end_box.y2) / 2,
-                color=end_box.outline,
-                width=1,
-                detour_y=detour_y,
-            )
-        elif draw_funnel_flag:
-            _draw_stacked_funnel(draw, start_box, end_box)
+        detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
+        draw_connector(
+            draw,
+            start_box.x2,
+            (start_box.y1 + start_box.y2) / 2,
+            end_box.x1,
+            (end_box.y1 + end_box.y2) / 2,
+            color=end_box.outline,
+            width=1,
+            detour_y=detour_y,
+        )
 
 
 def _draw_labels(


### PR DESCRIPTION
## Summary
Fixes a real visual regression introduced by the v2 backend unification (#79, #80), caught by @willyfh manually diffing ReadTheDocs' rendered `plot_basic_custom` example against a before-rewrite render.

The rewrite drew every connector before every box, instead of interleaving them column by column like the pre-rewrite implementation. For the small test models used to verify the rewrite, adjacent layers happened to have a similar 3D depth (`de`), so the two draw orders looked identical - which is why this passed every check at the time. On a real CNN, where `de` shrinks a lot layer to layer (e.g. 74px → 37px → 18px for `Conv2d(3,16)`/`Conv2d(16,32)`/`Conv2d(32,64)`), drawing every box on top of every funnel afterward let each box's opaque fill blot out large parts of its own incoming funnel line.

## Fix
Restored the original interleaving: for each column, draw its incoming (non-skip) funnels first, then that column's own boxes - matching the original per-box loop's effective z-order. Skip-connection lines are drawn in a separate final pass (they route above the diagram in a reserved margin, so they have no z-order conflict with box fills).

## Also included in this PR
- **New residual-block examples** for `layered`/`lenet` styles (`docs/examples/layered/plot_residual_block_layered.py`, `docs/examples/lenet_style/plot_residual_block_lenet_style.py`), mirroring the existing graph one - these styles only gained real branching support in #79/#80 and had nothing demonstrating it. Named with a style suffix (matching the existing `plot_basic_sequential_lenet_style.py` convention) to avoid a `mypy` duplicate-module error, since `docs/examples/*/*.py` has no `__init__.py` package markers.
- **Bumped Sphinx-Gallery's captured figure DPI to 300** (`docs/source/conf.py`) - matplotlib's default (100 DPI, 6.4x4.8in figure) caps every gallery image at 640x480px regardless of the actual generated diagram's size, visibly blurring fine detail once an example's output exceeds that. 300 DPI matches standard print/publication resolution, since these diagrams are meant to be usable directly in papers.

## Test plan
- [x] Verified pixel-identical to pre-rewrite `main` (1ee630e) for the reported model via a `git worktree` comparison
- [x] Same funnel fix applied and verified for `lenet_view` (same underlying pattern)
- [x] Added a regression test for the funnel bug class to both `test_layered.py` and `test_lenet_style.py` - a non-background pixel count assertion, since a canvas-size-only check (used elsewhere in this repo) doesn't catch it: box positions are unaffected by this bug, only which pixels get painted over
- [x] Both new residual examples run end-to-end and correctly show the skip connection routed above the diagram
- [x] Verified the DPI change empirically: captured figure resolution goes from ~640x480 to 1920x1440 for a wide example
- [x] `pytest tests/` - all 74 tests pass
- [x] `pre-commit run --all-files` - all hooks pass