### PR TITLE
Fix attention visibility and RNN shape misinterpretation

### DIFF
--- a/docs/examples/flow/plot_2d_view.py
+++ b/docs/examples/flow/plot_2d_view.py
@@ -28,7 +28,9 @@ model = nn.Sequential(
 input_shape = (1, 3, 224, 224)
 img = visualtorch.render(model, input_shape=input_shape, style="flow", draw_volume=False)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_basic_custom.py
+++ b/docs/examples/flow/plot_basic_custom.py
@@ -47,7 +47,9 @@ input_shape = (1, 3, 224, 224)
 
 img = visualtorch.render(model, input_shape=input_shape, style="flow", legend=True)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_basic_sequential.py
+++ b/docs/examples/flow/plot_basic_sequential.py
@@ -29,7 +29,9 @@ input_shape = (1, 3, 224, 224)
 
 img = visualtorch.render(model, input_shape=input_shape, style="flow", legend=True)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_custom_color.py
+++ b/docs/examples/flow/plot_custom_color.py
@@ -37,7 +37,9 @@ color_map[nn.Linear]["fill"] = "#0072B2"  # blue
 input_shape = (1, 3, 224, 224)
 img = visualtorch.render(model, input_shape=input_shape, style="flow", color_map=color_map)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_custom_opacity.py
+++ b/docs/examples/flow/plot_custom_opacity.py
@@ -29,7 +29,9 @@ input_shape = (1, 3, 224, 224)
 
 img = visualtorch.render(model, input_shape=input_shape, style="flow", opacity=100)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_custom_orientation.py
+++ b/docs/examples/flow/plot_custom_orientation.py
@@ -35,7 +35,9 @@ img = visualtorch.render(
     spacing=40,
 )
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_custom_shading.py
+++ b/docs/examples/flow/plot_custom_shading.py
@@ -28,7 +28,9 @@ model = nn.Sequential(
 input_shape = (1, 3, 224, 224)
 img = visualtorch.render(model, input_shape=input_shape, style="flow", shade_step=50)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_custom_spacing.py
+++ b/docs/examples/flow/plot_custom_spacing.py
@@ -29,7 +29,9 @@ input_shape = (1, 3, 224, 224)
 
 img = visualtorch.render(model, input_shape=input_shape, style="flow", spacing=50)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_dark_background.py
+++ b/docs/examples/flow/plot_dark_background.py
@@ -1,0 +1,49 @@
+"""Dark Background
+=======================================
+
+``background_fill`` isn't limited to plain white - it also accepts a transparent color
+(e.g. ``(0, 0, 0, 0)``), useful for dropping a figure onto a paper/slide without a white box
+around it, or an opaque dark color for a nicer look on dark-mode pages.
+
+Note: when using a non-white background, also set an ``outline`` per layer type in
+``color_map``. Box borders and funnel connector lines default to plain black, which becomes
+invisible against a dark or black background.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.BatchNorm2d(16),
+    nn.ReLU(),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.BatchNorm2d(32),
+    nn.ReLU(),
+)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#00F5FF"
+color_map[nn.Conv2d]["outline"] = "#E0FFFF"
+color_map[nn.BatchNorm2d]["fill"] = "#FF10F0"
+color_map[nn.BatchNorm2d]["outline"] = "#FFD1FA"
+color_map[nn.ReLU]["fill"] = "#FCEE09"
+color_map[nn.ReLU]["outline"] = "#FFFACD"
+
+input_shape = (1, 3, 32, 32)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="flow",
+    color_map=color_map,
+    background_fill="black",
+)
+
+plt.axis("off")
+plt.tight_layout()
+plt.imshow(img)
+plt.show()

--- a/docs/examples/flow/plot_dark_background.py
+++ b/docs/examples/flow/plot_dark_background.py
@@ -43,7 +43,9 @@ img = visualtorch.render(
     background_fill="black",
 )
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_ignore_layers.py
+++ b/docs/examples/flow/plot_ignore_layers.py
@@ -35,7 +35,9 @@ img = visualtorch.render(
     type_ignore=ignored_layers,
 )
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/flow/plot_residual_block_flow.py
+++ b/docs/examples/flow/plot_residual_block_flow.py
@@ -48,7 +48,9 @@ color_map[nn.ReLU]["fill"] = "#56B4E9"
 
 img = visualtorch.render(model, input_shape, style="flow", color_map=color_map, legend=True)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_basic_dense.py
+++ b/docs/examples/graph/plot_basic_dense.py
@@ -40,7 +40,9 @@ img = visualtorch.render(
     style="graph",
 )
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_custom_node_color.py
+++ b/docs/examples/graph/plot_custom_node_color.py
@@ -39,7 +39,9 @@ color_map[nn.Linear]["fill"] = "#009E73"  # bluish green
 
 img = visualtorch.render(model, input_shape, style="graph", color_map=color_map)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_custom_node_size.py
+++ b/docs/examples/graph/plot_custom_node_size.py
@@ -34,7 +34,9 @@ input_shape = (1, 4)
 
 img = visualtorch.render(model, input_shape, style="graph", node_size=100)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_custom_spacing_layers.py
+++ b/docs/examples/graph/plot_custom_spacing_layers.py
@@ -34,7 +34,9 @@ input_shape = (1, 4)
 
 img = visualtorch.render(model, input_shape, style="graph", layer_spacing=500)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_inception_block.py
+++ b/docs/examples/graph/plot_inception_block.py
@@ -65,7 +65,9 @@ color_map[nn.MaxPool2d]["fill"] = "#CC79A7"
 
 img = visualtorch.render(model, input_shape, style="graph", show_neurons=False, color_map=color_map, layer_spacing=60)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/graph/plot_residual_block.py
+++ b/docs/examples/graph/plot_residual_block.py
@@ -53,7 +53,9 @@ color_map[nn.ReLU]["fill"] = "#56B4E9"
 
 img = visualtorch.render(model, input_shape, style="graph", show_neurons=False, color_map=color_map, layer_spacing=60)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/lenet_style/plot_basic_sequential_lenet_style.py
+++ b/docs/examples/lenet_style/plot_basic_sequential_lenet_style.py
@@ -26,7 +26,9 @@ img = visualtorch.render(
     style="lenet",
 )
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/docs/examples/lenet_style/plot_residual_block_lenet_style.py
+++ b/docs/examples/lenet_style/plot_residual_block_lenet_style.py
@@ -48,7 +48,9 @@ color_map[nn.ReLU]["fill"] = "#56B4E9"
 
 img = visualtorch.render(model, input_shape, style="lenet", color_map=color_map)
 
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
 plt.axis("off")
 plt.tight_layout()
-plt.imshow(img)
 plt.show()

--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -1,6 +1,6 @@
 """Regression tests for shape-handling crashes reported in open GitHub issues.
 
-See https://github.com/willyfh/visualtorch/issues/63, /68, /69.
+See https://github.com/willyfh/visualtorch/issues/63, /68, /69, /84, /85.
 """
 
 # Copyright (C) 2024 Willy Fitra Hendria
@@ -9,6 +9,7 @@ See https://github.com/willyfh/visualtorch/issues/63, /68, /69.
 import pytest
 import torch
 from torch import nn
+from visualtorch.backend import extract_architecture
 from visualtorch.flow import flow_view
 from visualtorch.lenet_style import lenet_view
 from visualtorch.utils.utils import self_multiply
@@ -72,3 +73,49 @@ def test_lenet_view_rejects_multi_input_shape_with_clear_error() -> None:
 
     with pytest.raises(ValueError, match="single"):
         lenet_view(model, input_shape=multi_input_shape)
+
+
+def test_extract_architecture_records_multihead_attention_as_a_node() -> None:
+    """nn.MultiheadAttention has a child (out_proj) but computes attention via a fused
+    functional call on raw parameter tensors, never actually calling `self.out_proj(...)`.
+    Without a fallback, neither it nor its child would ever become a traced node, silently
+    dropping the attention computation from every render style. See issue #84.
+    """  # noqa: D205
+
+    class TinyTransformer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed = nn.Linear(16, 32)
+            encoder_layer = nn.TransformerEncoderLayer(d_model=32, nhead=4, dim_feedforward=64, batch_first=True)
+            self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=1)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.encoder(self.embed(x))
+
+    architecture = extract_architecture(TinyTransformer(), (1, 10, 16))
+    module_types = {type(layer.module) for column in architecture.columns for layer in column}
+
+    assert nn.MultiheadAttention in module_types
+
+
+def test_flow_view_lstm_sequence_length_does_not_inflate_diagram_height() -> None:
+    """An RNN's output shape (seq_len, hidden_size) has no channel axis. Before the fix,
+    seq_len was misread as a channel/extrusion count, drawing that many stacked volume slices -
+    illegible for any realistic sequence length. Diagram height must stay independent of
+    seq_len; only width should reflect it. See issue #85.
+    """  # noqa: D205
+
+    class LSTMModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lstm = nn.LSTM(input_size=10, hidden_size=20, batch_first=True)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            out, _ = self.lstm(x)
+            return out
+
+    model = LSTMModel()
+    short_img = flow_view(model, input_shape=(1, 5, 10))
+    long_img = flow_view(model, input_shape=(1, 200, 10))
+
+    assert long_img.height == short_img.height

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -234,6 +234,13 @@ def _box_factory(
             else:
                 error_msg = f"unsupported orientation: {one_dim_orientation}"
                 raise ValueError(error_msg)
+        elif len(shape) == 2:
+            # A 2D non-batch shape (e.g. (seq_len, hidden_size) from an RNN/attention layer)
+            # isn't a CNN feature map missing a channel dim - there's no channel axis at all.
+            # Box's "3D" skew (de, below) is driven by shape[1], so a dummy 1 goes there
+            # instead of either real dim, keeping the two real dims on the box's actual width
+            # and height instead of one of them inflating the skew for a long sequence.
+            shape = (shape[0], 1, shape[1])
 
         ori_shape = shape
         shape = shape + (1,) * (4 - len(shape))  # expand 4D.

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -216,6 +216,13 @@ def _box_factory(
             else:
                 error_msg = f"unsupported orientation: {one_dim_orientation}"
                 raise ValueError(error_msg)
+        elif len(shape) == 2:
+            # A 2D non-batch shape (e.g. (seq_len, hidden_size) from an RNN/attention layer)
+            # isn't a CNN feature map missing a channel dim - there's no channel axis at all.
+            # StackedBox's slice count (de, below) is driven by shape[0], so a dummy 1 goes
+            # there instead of either real dim, keeping the two real dims on the box's actual
+            # width and height instead of one of them being drawn as that many stacked slices.
+            shape = (1, *shape)
 
         ori_shape = shape
         shape = shape + (1,) * (4 - len(shape))  # expand 4D.

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -136,14 +136,18 @@ def _wrapped_module_call(
     def wrapped(mod: nn.Module, *args: Any, **kwargs: Any) -> Any:
         producer_ids = _collect_producer_ids(args) | _collect_producer_ids(kwargs)
 
+        edge_count_before = len(edges)
         out = _orig_module_call(mod, *args, **kwargs)
 
-        # Only leaf modules (no children) become graph nodes - containers such as
-        # nn.Sequential or a custom composite block are transparent plumbing. A leaf module
-        # invoked more than once (e.g. weight sharing) gets a distinct node per call, keyed by
-        # a call-index suffix, so repeat calls don't collapse into a self-referential node that
-        # can never be placed in the topological layering.
-        is_leaf = len(list(mod.children())) == 0
+        # A module becomes a graph node either because it's a leaf (no children - e.g. Conv2d)
+        # or because it has children but none of them actually fired during this call. The
+        # latter happens for modules like nn.MultiheadAttention: it has a child (out_proj), but
+        # its forward computes attention via a fused functional call on raw parameter tensors
+        # rather than calling `self.out_proj(...)`, so no descendant call is ever traced. Without
+        # this fallback, such modules would be silently invisible - neither they nor any child
+        # would ever become a node. Ordinary containers (nn.Sequential, etc.) always have at
+        # least one descendant call recorded, so they stay transparent as before.
+        is_leaf = len(list(mod.children())) == 0 or len(edges) == edge_count_before
         if is_leaf:
             base_id = id(mod)
             call_index = call_counts.get(base_id, 0)


### PR DESCRIPTION
## Summary
- Fixes #84: `nn.MultiheadAttention` was silently invisible in every render style because its forward pass bypasses child `nn.Module.__call__` dispatch. The tracer's leaf/container heuristic now falls back to treating a module as a leaf if it has children but none of them fired during its own call.
- Fixes #85: `flow`/`lenet` styles misread an RNN's `(seq_len, hidden_size)` output shape as a CNN channel count, drawing `seq_len` stacked volume slices. Both styles now special-case 2D shapes so neither real dimension drives the style's own "3D" extrusion metric.
- Fixes #86: adds `docs/examples/flow/plot_dark_background.py` demonstrating `background_fill` on a dark background with matching bright outlines.

## Test plan
- [x] `pytest tests/` (76 passed, incl. 2 new regression tests for #84/#85)
- [x] `pre-commit run --all-files` (run twice, both green)
- [x] Manually rendered a `TransformerEncoderLayer` model in all 3 styles - `MultiheadAttention` now appears as its own node
- [x] Manually rendered an `LSTM` model with varying sequence lengths (5/50/200) - diagram height/skew no longer grows with sequence length