### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="0.2.5",
+    version="1.0.0",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     description="Architecture visualization of Torch models",


### PR DESCRIPTION
## Summary
Bumps `setup.py`'s version from `0.2.5` to `1.0.0`.

Since the last release (`v0.2.5`), the API has been substantially reworked: a single unified backend (`extract_architecture`) powering all three render styles, a single `render()` entry point replacing three separate functions, the `layered`→`flow` rename, Okabe-Ito default colors, real branching/skip-connection support, attention/RNN correctness fixes, and multi-input model support. This is a deliberate 1.0.0 (not 0.3.0) to declare the current `render()` API as the stable public surface going forward - see PR #83/#87/#88 for the full breaking-change history.

Not creating the GitHub Release / tag as part of this PR - that's a separate, explicit step once this is merged (per the established release process), since it triggers the PyPI publish.