### PR TITLE
Make skip-connection detour routing collision-aware

### DIFF
--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -68,7 +68,10 @@ def test_compute_skip_levels_keeps_level_when_intervening_box_collides() -> None
     }
 
     edge_to_level, num_levels = compute_skip_levels(
-        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes[node_id]
+        [("a", "b")],
+        id_to_column,
+        lambda *_: True,
+        lambda node_id: bboxes[node_id],
     )
 
     assert num_levels == 1
@@ -85,7 +88,10 @@ def test_compute_skip_levels_drops_level_when_intervening_box_is_a_different_row
     }
 
     edge_to_level, num_levels = compute_skip_levels(
-        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes[node_id]
+        [("a", "b")],
+        id_to_column,
+        lambda *_: True,
+        lambda node_id: bboxes[node_id],
     )
 
     assert edge_to_level == {}
@@ -98,7 +104,10 @@ def test_compute_skip_levels_missing_bbox_conservatively_assumes_collision() -> 
     bboxes = {"a": (0.0, 0.0, 10.0, 10.0), "b": (40.0, 0.0, 50.0, 10.0)}
 
     edge_to_level, num_levels = compute_skip_levels(
-        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes.get(node_id)
+        [("a", "b")],
+        id_to_column,
+        lambda *_: True,
+        lambda node_id: bboxes.get(node_id),
     )
 
     assert num_levels == 1
@@ -119,48 +128,60 @@ def test_compute_skip_levels_missing_endpoint_bbox_conservatively_assumes_collis
 
 
 def test_segment_intersects_rect_segment_fully_inside() -> None:
+    """A segment entirely within the rect counts as intersecting."""
     assert _segment_intersects_rect(2, 2, 8, 8, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_segment_crosses_through_middle() -> None:
+    """A segment passing straight through the rect's interior intersects."""
     assert _segment_intersects_rect(-5, 5, 15, 5, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_segment_passes_above() -> None:
+    """A segment entirely above the rect doesn't intersect."""
     assert _segment_intersects_rect(-5, -20, 15, -20, 0, 0, 10, 10) is False
 
 
 def test_segment_intersects_rect_segment_passes_below() -> None:
+    """A segment entirely below the rect doesn't intersect."""
     assert _segment_intersects_rect(-5, 50, 15, 50, 0, 0, 10, 10) is False
 
 
 def test_segment_intersects_rect_touches_one_corner() -> None:
+    """Touching exactly one corner counts as intersecting (conservative)."""
     assert _segment_intersects_rect(-5, -5, 0, 0, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_touches_one_edge() -> None:
+    """Touching exactly one edge counts as intersecting (conservative)."""
     assert _segment_intersects_rect(-5, 5, 0, 5, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_horizontal_segment_clear() -> None:
+    """A horizontal segment clear of the rect doesn't intersect."""
     assert _segment_intersects_rect(-5, -5, 15, -5, 0, 0, 10, 10) is False
 
 
 def test_segment_intersects_rect_horizontal_segment_through_rect() -> None:
+    """A horizontal segment passing through the rect intersects."""
     assert _segment_intersects_rect(-5, 5, 15, 5, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_vertical_segment_through_rect() -> None:
+    """A vertical segment passing through the rect intersects."""
     assert _segment_intersects_rect(5, -5, 5, 15, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_vertical_segment_clear() -> None:
+    """A vertical segment clear of the rect doesn't intersect."""
     assert _segment_intersects_rect(50, -5, 50, 15, 0, 0, 10, 10) is False
 
 
 def test_segment_intersects_rect_degenerate_point_inside() -> None:
+    """A zero-length segment (a point) inside the rect counts as intersecting."""
     assert _segment_intersects_rect(5, 5, 5, 5, 0, 0, 10, 10) is True
 
 
 def test_segment_intersects_rect_degenerate_point_outside() -> None:
+    """A zero-length segment (a point) outside the rect doesn't intersect."""
     assert _segment_intersects_rect(50, 50, 50, 50, 0, 0, 10, 10) is False

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,166 @@
+"""Tests for the frontend-agnostic connector-routing helpers."""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+from visualtorch.connectors import _segment_intersects_rect, compute_skip_levels
+
+
+def _no_bbox(_node_id: str) -> tuple[float, float, float, float] | None:
+    return None
+
+
+# ---- compute_skip_levels: span/content gating ----
+
+
+def test_compute_skip_levels_ignores_span_le_1_edges() -> None:
+    """An edge with column span <= 1 should never be assigned a detour level."""
+    id_to_column = {"a": 0, "b": 1}
+
+    edge_to_level, num_levels = compute_skip_levels([("a", "b")], id_to_column, lambda *_: True, _no_bbox)
+
+    assert edge_to_level == {}
+    assert num_levels == 0
+
+
+def test_compute_skip_levels_assigns_distinct_levels_to_overlapping_skips() -> None:
+    """Two skip edges whose column spans genuinely overlap must get different levels."""
+    id_to_column = {"a": 0, "b": 3, "c": 2, "d": 5}
+    edges = [("a", "b"), ("c", "d")]
+
+    edge_to_level, num_levels = compute_skip_levels(edges, id_to_column, lambda *_: True, _no_bbox)
+
+    assert num_levels == 2
+    assert edge_to_level[("a", "b")] != edge_to_level[("c", "d")]
+
+
+def test_compute_skip_levels_allows_touching_intervals_to_share_a_level() -> None:
+    """Two skip edges that only touch at a shared column boundary can share a level."""
+    id_to_column = {"a": 0, "b": 3, "c": 3, "d": 5}
+    edges = [("a", "b"), ("c", "d")]
+
+    edge_to_level, num_levels = compute_skip_levels(edges, id_to_column, lambda *_: True, _no_bbox)
+
+    assert num_levels == 1
+    assert edge_to_level[("a", "b")] == edge_to_level[("c", "d")] == 0
+
+
+def test_compute_skip_levels_ignores_edges_with_no_content() -> None:
+    """A skip edge that `edge_has_content` reports as empty shouldn't consume a level."""
+    id_to_column = {"a": 0, "b": 3}
+
+    edge_to_level, num_levels = compute_skip_levels([("a", "b")], id_to_column, lambda *_: False, _no_bbox)
+
+    assert edge_to_level == {}
+    assert num_levels == 0
+
+
+# ---- compute_skip_levels: collision-awareness ----
+
+
+def test_compute_skip_levels_keeps_level_when_intervening_box_collides() -> None:
+    """A span>1 edge whose straight line genuinely crosses an intervening same-row box."""
+    id_to_column = {"a": 0, "mid": 1, "b": 2}
+    bboxes = {
+        "a": (0.0, 0.0, 10.0, 10.0),
+        "mid": (20.0, 0.0, 30.0, 10.0),  # same row (y=0..10) as a and b - directly in the path
+        "b": (40.0, 0.0, 50.0, 10.0),
+    }
+
+    edge_to_level, num_levels = compute_skip_levels(
+        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes[node_id]
+    )
+
+    assert num_levels == 1
+    assert edge_to_level[("a", "b")] == 0
+
+
+def test_compute_skip_levels_drops_level_when_intervening_box_is_a_different_row() -> None:
+    """A span>1 edge whose straight line passes clear of an intervening box in a different row."""
+    id_to_column = {"a": 0, "mid": 1, "b": 2}
+    bboxes = {
+        "a": (0.0, 0.0, 10.0, 10.0),
+        "mid": (20.0, 100.0, 30.0, 110.0),  # a different row entirely - well below the line
+        "b": (40.0, 0.0, 50.0, 10.0),
+    }
+
+    edge_to_level, num_levels = compute_skip_levels(
+        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes[node_id]
+    )
+
+    assert edge_to_level == {}
+    assert num_levels == 0
+
+
+def test_compute_skip_levels_missing_bbox_conservatively_assumes_collision() -> None:
+    """If an intervening id's bbox can't be resolved, assume a collision rather than guessing clear."""
+    id_to_column = {"a": 0, "mid": 1, "b": 2}
+    bboxes = {"a": (0.0, 0.0, 10.0, 10.0), "b": (40.0, 0.0, 50.0, 10.0)}
+
+    edge_to_level, num_levels = compute_skip_levels(
+        [("a", "b")], id_to_column, lambda *_: True, lambda node_id: bboxes.get(node_id)
+    )
+
+    assert num_levels == 1
+    assert edge_to_level[("a", "b")] == 0
+
+
+def test_compute_skip_levels_missing_endpoint_bbox_conservatively_assumes_collision() -> None:
+    """If the edge's own start/end bbox can't be resolved, also assume a collision."""
+    id_to_column = {"a": 0, "b": 2}
+
+    edge_to_level, num_levels = compute_skip_levels([("a", "b")], id_to_column, lambda *_: True, _no_bbox)
+
+    assert num_levels == 1
+    assert edge_to_level[("a", "b")] == 0
+
+
+# ---- _segment_intersects_rect ----
+
+
+def test_segment_intersects_rect_segment_fully_inside() -> None:
+    assert _segment_intersects_rect(2, 2, 8, 8, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_segment_crosses_through_middle() -> None:
+    assert _segment_intersects_rect(-5, 5, 15, 5, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_segment_passes_above() -> None:
+    assert _segment_intersects_rect(-5, -20, 15, -20, 0, 0, 10, 10) is False
+
+
+def test_segment_intersects_rect_segment_passes_below() -> None:
+    assert _segment_intersects_rect(-5, 50, 15, 50, 0, 0, 10, 10) is False
+
+
+def test_segment_intersects_rect_touches_one_corner() -> None:
+    assert _segment_intersects_rect(-5, -5, 0, 0, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_touches_one_edge() -> None:
+    assert _segment_intersects_rect(-5, 5, 0, 5, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_horizontal_segment_clear() -> None:
+    assert _segment_intersects_rect(-5, -5, 15, -5, 0, 0, 10, 10) is False
+
+
+def test_segment_intersects_rect_horizontal_segment_through_rect() -> None:
+    assert _segment_intersects_rect(-5, 5, 15, 5, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_vertical_segment_through_rect() -> None:
+    assert _segment_intersects_rect(5, -5, 5, 15, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_vertical_segment_clear() -> None:
+    assert _segment_intersects_rect(50, -5, 50, 15, 0, 0, 10, 10) is False
+
+
+def test_segment_intersects_rect_degenerate_point_inside() -> None:
+    assert _segment_intersects_rect(5, 5, 5, 5, 0, 0, 10, 10) is True
+
+
+def test_segment_intersects_rect_degenerate_point_outside() -> None:
+    assert _segment_intersects_rect(50, 50, 50, 50, 0, 0, 10, 10) is False

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -471,3 +471,59 @@ def test_flow_view_shows_all_input_boxes_for_multi_input_model() -> None:
 
     img = flow_view(TwoInputNet(), input_shape=((1, 4), (1, 4)))
     assert img is not None
+
+
+def test_flow_view_mismatched_depth_siamese_branches_needs_no_detour() -> None:
+    """Sibling branches of different depths merging shouldn't trigger a routed detour."""
+
+    class SiameseNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.image_branch = nn.Sequential(
+                nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1),
+                nn.ReLU(),
+                nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
+            )
+            self.vector_branch = nn.Sequential(
+                nn.Linear(10, 8),
+                nn.ReLU(),
+            )
+            self.head = nn.Linear(16, 4)
+
+        def forward(self, image: torch.Tensor, vector: torch.Tensor) -> torch.Tensor:
+            """Run each branch on its own input tensor, then concatenate and project."""
+            image_features = self.image_branch(image)
+            vector_features = self.vector_branch(vector)
+            merged = torch.cat([image_features, vector_features], dim=1)
+            return self.head(merged)
+
+    class SiameseNetDepthMatched(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.image_branch = nn.Sequential(
+                nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1),
+                nn.ReLU(),
+                nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
+            )
+            self.vector_branch = nn.Sequential(
+                nn.Linear(10, 8),
+                nn.ReLU(),
+                nn.Linear(8, 8),
+                nn.ReLU(),
+            )
+            self.head = nn.Linear(16, 4)
+
+        def forward(self, image: torch.Tensor, vector: torch.Tensor) -> torch.Tensor:
+            """Run each branch on its own input tensor, then concatenate and project."""
+            image_features = self.image_branch(image)
+            vector_features = self.vector_branch(vector)
+            merged = torch.cat([image_features, vector_features], dim=1)
+            return self.head(merged)
+
+    input_shape = ((1, 3, 16, 16), (1, 10))
+    img_mismatched = flow_view(SiameseNet(), input_shape=input_shape)
+    img_matched = flow_view(SiameseNetDepthMatched(), input_shape=input_shape)
+
+    assert img_mismatched.size[1] == img_matched.size[1]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,7 +10,6 @@ import torch
 from PIL import Image
 from torch import nn
 from visualtorch.backend import extract_architecture
-from visualtorch.connectors import compute_skip_levels
 from visualtorch.graph import graph_view
 
 
@@ -281,46 +280,73 @@ def test_graph_view_show_dimension_with_branching(residual_model: nn.Module) -> 
     assert img is not None
 
 
-def test_compute_skip_levels_ignores_span_le_1_edges() -> None:
-    """An edge with column span <= 1 should never be assigned a detour level."""
-    id_to_column = {"a": 0, "b": 1}
+def test_graph_view_mismatched_depth_siamese_branches_needs_no_detour() -> None:
+    """Sibling branches of different depths merging shouldn't trigger a routed detour.
 
-    edge_to_level, num_levels = compute_skip_levels([("a", "b")], id_to_column, lambda *_: True)
+    Compares against a depth-matched control (the shorter branch padded to the same depth, so
+    both branches merge at the same column, i.e. span == 1 - a case already known/confirmed to
+    need zero detour rows) and asserts the two images have the same height. This is more robust
+    than a hardcoded pixel baseline (an arbitrary implementation-detail number) and more precise
+    than "with vs without the whole skip connection" (this bug is about a false-positive skip
+    classification, not about whether a skip exists at all).
+    """
 
-    assert edge_to_level == {}
-    assert num_levels == 0
+    class SiameseNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.image_branch = nn.Sequential(
+                nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1),
+                nn.ReLU(),
+                nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
+            )
+            self.vector_branch = nn.Sequential(
+                nn.Linear(10, 8),
+                nn.ReLU(),
+            )
+            self.head = nn.Linear(16, 4)
 
+        def forward(self, image: torch.Tensor, vector: torch.Tensor) -> torch.Tensor:
+            """Run each branch on its own input tensor, then concatenate and project."""
+            image_features = self.image_branch(image)
+            vector_features = self.vector_branch(vector)
+            merged = torch.cat([image_features, vector_features], dim=1)
+            return self.head(merged)
 
-def test_compute_skip_levels_assigns_distinct_levels_to_overlapping_skips() -> None:
-    """Two skip edges whose column spans genuinely overlap must get different levels."""
-    id_to_column = {"a": 0, "b": 3, "c": 2, "d": 5}
-    edges = [("a", "b"), ("c", "d")]
+    class SiameseNetDepthMatched(nn.Module):
+        """Same topology, but vector_branch padded with an extra Linear(8, 8)+ReLU pair so both
+        branches reach the merge point at the same column - a control case known to need 0
+        detour levels today (span == 1 at the merge).
+        """  # noqa: D205
 
-    edge_to_level, num_levels = compute_skip_levels(edges, id_to_column, lambda *_: True)
+        def __init__(self) -> None:
+            super().__init__()
+            self.image_branch = nn.Sequential(
+                nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1),
+                nn.ReLU(),
+                nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
+            )
+            self.vector_branch = nn.Sequential(
+                nn.Linear(10, 8),
+                nn.ReLU(),
+                nn.Linear(8, 8),
+                nn.ReLU(),
+            )
+            self.head = nn.Linear(16, 4)
 
-    assert num_levels == 2
-    assert edge_to_level[("a", "b")] != edge_to_level[("c", "d")]
+        def forward(self, image: torch.Tensor, vector: torch.Tensor) -> torch.Tensor:
+            """Run each branch on its own input tensor, then concatenate and project."""
+            image_features = self.image_branch(image)
+            vector_features = self.vector_branch(vector)
+            merged = torch.cat([image_features, vector_features], dim=1)
+            return self.head(merged)
 
+    input_shape = ((1, 3, 16, 16), (1, 10))
+    img_mismatched = graph_view(SiameseNet(), input_shape=input_shape, show_neurons=False)
+    img_matched = graph_view(SiameseNetDepthMatched(), input_shape=input_shape, show_neurons=False)
 
-def test_compute_skip_levels_allows_touching_intervals_to_share_a_level() -> None:
-    """Two skip edges that only touch at a shared column boundary can share a level."""
-    id_to_column = {"a": 0, "b": 3, "c": 3, "d": 5}
-    edges = [("a", "b"), ("c", "d")]
-
-    edge_to_level, num_levels = compute_skip_levels(edges, id_to_column, lambda *_: True)
-
-    assert num_levels == 1
-    assert edge_to_level[("a", "b")] == edge_to_level[("c", "d")] == 0
-
-
-def test_compute_skip_levels_ignores_edges_with_no_content() -> None:
-    """A skip edge that `edge_has_content` reports as empty shouldn't consume a level."""
-    id_to_column = {"a": 0, "b": 3}
-
-    edge_to_level, num_levels = compute_skip_levels([("a", "b")], id_to_column, lambda *_: False)
-
-    assert edge_to_level == {}
-    assert num_levels == 0
+    assert img_mismatched.size[1] == img_matched.size[1]
 
 
 def test_graph_view_residual_model_routes_above_diagram(residual_model: nn.Module) -> None:

--- a/visualtorch/_volumetric_layout.py
+++ b/visualtorch/_volumetric_layout.py
@@ -33,6 +33,13 @@ class ColumnLayout:
     img_width: float
     x_off: float
 
+    def bbox_for(self, node_id: str) -> tuple[float, float, float, float] | None:
+        """A node's `(x1, y1, x2, y2)` bounding box, or None if it has no box (e.g. type_ignore'd)."""
+        box = self.id_to_box.get(node_id)
+        if box is None:
+            return None
+        return box.x1, box.y1, box.x2, box.y2
+
 
 def _default_top_offset(box: VolumetricBox) -> float:
     return getattr(box, "de", 0)

--- a/visualtorch/connectors.py
+++ b/visualtorch/connectors.py
@@ -19,14 +19,24 @@ def compute_skip_levels(
     edges: Iterable[tuple[str, str]],
     id_to_column: dict[str, int],
     edge_has_content: Callable[[str, str], bool],
+    get_bbox: Callable[[str], tuple[float, float, float, float] | None],
 ) -> tuple[dict[tuple[str, str], int], int]:
-    """Assign a detour level to every edge whose column span is > 1 (a genuine skip).
+    """Assign a detour level to every edge whose column span is > 1 AND would actually collide.
 
-    Levels are assigned via greedy interval-graph-coloring over each edge's (start_col, end_col)
-    span, so that skip connections whose spans overlap never share a level (and so never draw
-    collinear with each other), while non-overlapping spans - e.g. back-to-back residual blocks -
-    can safely share the same level. Edges that would draw nothing (per `edge_has_content`) don't
-    consume a level.
+    A span > 1 edge is a genuine skip connection needing a routed detour only if a straight line
+    between its two connection points would visually intersect some *other* node's box in one of
+    the intervening columns - e.g. a residual connection bypassing same-row layers. A span > 1
+    edge whose intervening columns are all occupied by boxes in a *different* row (e.g. a sibling
+    branch that's simply deeper than this one, with no shared row) draws a clear diagonal line
+    with nothing behind it, and is treated exactly like an ordinary adjacent-column edge instead
+    (never enters the returned `edge_to_level`, so callers see `level is None` and draw a plain
+    line with no detour).
+
+    Levels are assigned via greedy interval-graph-coloring over each qualifying edge's
+    (start_col, end_col) span, so that skip connections whose spans overlap never share a level
+    (and so never draw collinear with each other), while non-overlapping spans - e.g. back-to-back
+    residual blocks - can safely share the same level. Edges that would draw nothing (per
+    `edge_has_content`) don't consume a level.
 
     Args:
         edges (Iterable): The model's `(start_id, end_id)` edges, e.g. from `Architecture.edges()`.
@@ -34,20 +44,31 @@ def compute_skip_levels(
         edge_has_content (Callable): Given `(start_id, end_id)`, returns whether this edge would
             actually draw something visible - a frontend-specific check (e.g. `graph_view`'s
             per-neuron `Ellipses` gating), kept out of this module entirely.
+        get_bbox (Callable): Given a node ID, returns its `(x1, y1, x2, y2)` pixel bounding box, or
+            `None` if that ID has no drawable box (e.g. filtered out by `type_ignore`) - kept
+            generic so this module stays unaware of any specific box/node class, matching
+            `edge_has_content`'s design.
 
     Returns:
         tuple: A tuple containing:
             - edge_to_level (dict): Mapping from `(start_id, end_id)` to its detour level (0 =
-                closest to the diagram). Only contains edges with span > 1 that draw something.
+                closest to the diagram). Only contains edges with span > 1 that draw something
+                and would actually collide with an intervening box.
             - num_levels (int): Total distinct levels used (0 if there are no qualifying edges).
     """
+    column_to_ids: dict[int, list[str]] = {}
+    for node_id, col in id_to_column.items():
+        column_to_ids.setdefault(col, []).append(node_id)
+
     intervals: list[tuple[int, int, tuple[str, str]]] = []
     for start_id, end_id in edges:
         start_col = id_to_column[start_id]
         end_col = id_to_column[end_id]
         if end_col - start_col <= 1:
             continue
-        if edge_has_content(start_id, end_id):
+        if not edge_has_content(start_id, end_id):
+            continue
+        if _skip_edge_collides(start_id, end_id, start_col, end_col, column_to_ids, get_bbox):
             intervals.append((start_col, end_col, (start_id, end_id)))
 
     intervals.sort(key=lambda interval: interval[0])
@@ -65,6 +86,95 @@ def compute_skip_levels(
             edge_to_level[edge_key] = len(levels) - 1
 
     return edge_to_level, len(levels)
+
+
+def _skip_edge_collides(
+    start_id: str,
+    end_id: str,
+    start_col: int,
+    end_col: int,
+    column_to_ids: dict[int, list[str]],
+    get_bbox: Callable[[str], tuple[float, float, float, float] | None],
+) -> bool:
+    """Whether a straight line from start_id's to end_id's connection point would visually
+    intersect some *other* node's box in one of the strictly-intervening columns.
+
+    If either endpoint has no bbox, geometry can't be evaluated - conservatively assume a
+    collision (keep the always-detour behavior) rather than silently dropping the route.
+    """  # noqa: D205
+    start_bbox = get_bbox(start_id)
+    end_bbox = get_bbox(end_id)
+    if start_bbox is None or end_bbox is None:
+        return True
+
+    sx1, sy1, sx2, sy2 = start_bbox
+    ex1, ey1, ex2, ey2 = end_bbox
+    line_x1, line_y1 = sx2, (sy1 + sy2) / 2
+    line_x2, line_y2 = ex1, (ey1 + ey2) / 2
+
+    for col in range(start_col + 1, end_col):
+        for other_id in column_to_ids.get(col, []):
+            other_bbox = get_bbox(other_id)
+            if other_bbox is None:
+                # Can't evaluate this obstacle's geometry - conservatively assume it collides
+                # rather than silently treating an unresolvable box as if it weren't there.
+                return True
+            if _segment_intersects_rect(line_x1, line_y1, line_x2, line_y2, *other_bbox):
+                return True
+    return False
+
+
+def _segment_intersects_rect(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    rx1: float,
+    ry1: float,
+    rx2: float,
+    ry2: float,
+) -> bool:
+    """Whether the segment (x1,y1)-(x2,y2) intersects the axis-aligned rect [rx1,ry1,rx2,ry2].
+
+    Conservative: touching an edge or corner counts as intersecting (a false-positive detour is
+    far less harmful than a straight line silently drawn through a box). Implemented as a
+    Liang-Barsky clip: the segment is parameterized as P(t) = (x1,y1) + t*(dx,dy) for t in
+    [0, 1], and each of the rect's 4 half-plane constraints tightens the surviving [t0, t1]
+    range. If [t0, t1] is non-empty at the end, some point of the segment lies inside (or on the
+    boundary of) the rect. This handles horizontal/vertical/degenerate (dx==0 and/or dy==0,
+    including a zero-length point segment) segments uniformly, with no special-casing.
+    """
+    rx_lo, rx_hi = (rx1, rx2) if rx1 <= rx2 else (rx2, rx1)
+    ry_lo, ry_hi = (ry1, ry2) if ry1 <= ry2 else (ry2, ry1)
+
+    dx = x2 - x1
+    dy = y2 - y1
+    t0, t1 = 0.0, 1.0
+
+    # p*t <= q for each of the 4 half-plane boundaries (left, right, top, bottom).
+    for p, q in (
+        (-dx, x1 - rx_lo),
+        (dx, rx_hi - x1),
+        (-dy, y1 - ry_lo),
+        (dy, ry_hi - y1),
+    ):
+        if p == 0:
+            # Segment is parallel to this pair of edges: if it's already outside on this axis,
+            # no t can bring it back in - reject outright, regardless of the other axis.
+            if q < 0:
+                return False
+            continue
+        t = q / p
+        if p < 0:
+            if t > t1:
+                return False
+            t0 = max(t0, t)
+        else:
+            if t < t0:
+                return False
+            t1 = min(t1, t)
+
+    return t0 <= t1
 
 
 def draw_connector(

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -152,6 +152,7 @@ def flow_view(
         ),
         architecture.id_to_column,
         lambda *_: True,
+        column_layout.bbox_for,
     )
     resolved_level_gap = level_gap if level_gap is not None else 50
     top_margin_for_skips = num_levels * resolved_level_gap

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -101,6 +101,7 @@ def graph_view(
         architecture.edges(),
         architecture.id_to_column,
         lambda start_id, end_id: _edge_draws_visible_content(id_to_node_list_map, start_id, end_id),
+        lambda node_id: _union_bbox(id_to_node_list_map.get(node_id, [])),
     )
     resolved_level_gap = level_gap if level_gap is not None else node_size
     top_margin_for_skips = num_levels * resolved_level_gap
@@ -175,6 +176,23 @@ def _edge_draws_visible_content(id_to_node_list_map: dict[str, list], start_id: 
         not isinstance(start_node, Ellipses) and not isinstance(end_node, Ellipses)
         for start_node in id_to_node_list_map[start_id]
         for end_node in id_to_node_list_map[end_id]
+    )
+
+
+def _union_bbox(nodes: list[Circle | Box | Ellipses]) -> tuple[float, float, float, float] | None:
+    """The union bounding box over a list of shapes, or None if the list is empty.
+
+    Includes Ellipses nodes (unlike `_edge_draws_visible_content`) - an ellipsis marker still
+    occupies screen space a connector line could cross, so it's a real obstacle for collision
+    purposes even though it wouldn't itself be a meaningful connector endpoint.
+    """
+    if not nodes:
+        return None
+    return (
+        min(node.x1 for node in nodes),
+        min(node.y1 for node in nodes),
+        max(node.x2 for node in nodes),
+        max(node.y2 for node in nodes),
     )
 
 

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -136,6 +136,7 @@ def lenet_view(
         architecture.edges(),
         architecture.id_to_column,
         lambda *_: True,
+        column_layout.bbox_for,
     )
     resolved_level_gap = level_gap if level_gap is not None else 50
     top_margin_for_skips = num_levels * resolved_level_gap


### PR DESCRIPTION
## Summary
- Any edge spanning >1 column was unconditionally treated as a skip connection needing a routed detour above the diagram - correct for genuine residual connections, but also incorrectly triggered for sibling branches of different depths merging into one node (discovered while building the multi-input Kaggle notebook example - a two-branch model with unequal branch depths drew an ugly rectangular detour for what's just a normal merge).
- `compute_skip_levels` now takes a `get_bbox` callable and only assigns a detour level if a straight line between an edge's endpoints would actually collide with some other node's box in an intervening column (Liang-Barsky segment/rect test; conservative - assumes collision when geometry can't be resolved).
- Zero changes needed in any of the 3 renderers' drawing loops - a collision-clear edge is automatically picked up by the existing "ordinary edge" drawing path, since all three already branch purely on `edge_to_level.get(...) is None`.

## Test plan
- [x] `pytest tests/` (108 passed - new `tests/test_connectors.py` with direct unit tests of the collision geometry, plus mismatched-depth regression tests in `test_graph.py`/`test_flow.py`)
- [x] `pre-commit run --all-files` (run twice, both green)
- [x] Manually re-rendered the mismatched-depth Siamese model - detour rectangle is gone, replaced by a clean direct line
- [x] Manually re-rendered a genuine residual block - skip connection still correctly routed above the diagram, unaffected