### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: "Willy Fitra"
 repository-code: "https://github.com/willyfh/visualtorch"
 license: MIT
-version: 1.0.0
-date-released: "2026-07-02"
+version: 1.1.0
+date-released: "2026-07-04"
 preferred-citation:
   type: article
   title: "VisualTorch: Streamlining Visualization for PyTorch Neural Network Architectures"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **VisualTorch** aims to help visualize Torch-based neural network architectures. It currently supports generating flow-style, graph-style, and LeNet-style architectures for PyTorch Sequential and Custom models. This tool is adapted from [visualkeras](https://github.com/paulgavrikov/visualkeras), [pytorchviz](https://github.com/szagoruyko/pytorchviz), and [pytorch-summary](https://github.com/sksq96/pytorch-summary).
 
-**Note:** `1.0.0` is a major release with breaking API changes, but with significantly better features and algorithms - upgrading is recommended. For the old API, use `0.2.5` or older.
+**Note:** `1.0+` is a major release with breaking API changes, but with significantly better features and algorithms - upgrading is recommended. For the old API, use `0.2.5` or older.
 
 **Limitation:** VisualTorch traces a real forward pass to build the diagram, which has two inherent
 limitations shared by any tracing-based approach (not bugs, and not fixable without full symbolic

--- a/docs/source/markdown/get_started/installation.md
+++ b/docs/source/markdown/get_started/installation.md
@@ -30,7 +30,7 @@ VisualTorch can be installed using the following commands:
 
 :::::
 
-Note: `1.0.0` is a major release with breaking API changes, but with significantly better
+Note: `1.0+` is a major release with breaking API changes, but with significantly better
 features and algorithms - upgrading is recommended. For the old API, use `0.2.5` or older
 (`pip install visualtorch==0.2.5`), with docs at
 [readthedocs.io/en/v0.2.5](https://visualtorch.readthedocs.io/en/v0.2.5/).

--- a/docs/source/snippets/install/pypi.txt
+++ b/docs/source/snippets/install/pypi.txt
@@ -1,1 +1,1 @@
-pip install visualtorch
+pip install visualtorch==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="1.0.0",
+    version="1.1.0",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     description="Architecture visualization of Torch models",


### PR DESCRIPTION
## Summary
- Bumps version to 1.1.0 in setup.py and CITATION.cff, ahead of the release.
- Rewords the pre-1.0 API migration note to say "1.0+" instead of "1.0.0" so it stays accurate across future 1.x releases.
- Pins the primary install snippet to `pip install visualtorch==1.1.0`.