### PR TITLE
Make Research Showcase paper links clickable

### DIFF
--- a/docs/source/markdown/showcase/index.md
+++ b/docs/source/markdown/showcase/index.md
@@ -14,7 +14,7 @@ Published research that has used VisualTorch to visualize model architectures.
 
 **Authors:** Nersesyan, L. E., Boiko, D. A., Kurbanalieva, S., Dzhemileva, L. U., Kozlov, K. S., Ananikov, V. P. (2026)
 **Venue:** _npj Biofilms and Microbiomes_
-**Link:** https://www.nature.com/articles/s41522-026-00971-3
+**Link:** [https://www.nature.com/articles/s41522-026-00971-3](https://www.nature.com/articles/s41522-026-00971-3)
 
 Models early-stage bacterial biofilms as interaction graphs (cells as vertices, predicted
 intercellular interactions as edges), combining Mask R-CNN for cell segmentation with a custom
@@ -29,7 +29,7 @@ substrate type from image-derived graph features.
 
 **Authors:** Brady, A., Moore-Hill, D., Khan, F., Daoud, H. (2026)
 **Venue:** IEEE International Symposium on Circuits and Systems (ISCAS)
-**Link:** https://ieeexplore.ieee.org/document/11562867
+**Link:** [https://ieeexplore.ieee.org/document/11562867](https://ieeexplore.ieee.org/document/11562867)
 
 A patient-specific model, trained on the CHB-MIT scalp EEG dataset, that combines convolutional
 layers with Leaky Integrate-and-Fire spiking neurons and a recurrent network to detect pre-ictal
@@ -44,7 +44,7 @@ power-constrained, on-device seizure prediction for wearable/IoT devices.
 
 **Authors:** Bonfini, P., Schetakis, N., Sukhnandan, J., Drosopoulos, G. A., Stavroulakis, G. E. (2026)
 **Venue:** _Materials_ (MDPI)
-**Link:** https://www.mdpi.com/1996-1944/19/5/878
+**Link:** [https://www.mdpi.com/1996-1944/19/5/878](https://www.mdpi.com/1996-1944/19/5/878)
 
 Trains a CNN on physics-based finite element simulations to predict equivalent plastic strain
 (failure distribution) on steel plate shear walls from building geometry and seismic intensity,


### PR DESCRIPTION
## Summary
- All three "Link:" entries on the Research Showcase page were plain bare URLs, not markdown hyperlinks. MyST's `linkify` extension isn't enabled in `conf.py`, so they rendered as inert plain text on the live docs site (confirmed via the built page) instead of clickable links.
- Wraps each in `[url](url)` so readers can actually click through to the papers.

Docs-only change, no version bump/release needed.