### PR TITLE
Fix typos in CONTRIBUTING.md and document adding gallery examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The [GitHub Discussions](https://github.com/willyfh/visualtorch/discussions/) is
 
 #### 1. Fork and Clone the Repository
 
-Fork the VisualTorch repository by following the GitHub documentation on [forking a repo](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo). fter forking, clone your forked repository to your local machine, and then create a new branch from the `main`` branch."
+Fork the VisualTorch repository by following the GitHub documentation on [forking a repo](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo). After forking, clone your forked repository to your local machine, and then create a new branch from the `main` branch.
 
 #### 2. Set Up Your Development Environment
 
@@ -53,7 +53,7 @@ pre-commit run --all-files
 
 ### Making Changes
 
-1. **Write Code:** Follow the project's coding standards and write your code with clear intent. Ensure your code is well-documented and includes examples where appropriate. For code quality we use `ruff``.
+1. **Write Code:** Follow the project's coding standards and write your code with clear intent. Ensure your code is well-documented and includes examples where appropriate. For code quality we use `ruff`.
 
 2. **Add Tests:** If your code includes new functionality, add corresponding tests using `pytest`.
 
@@ -67,6 +67,21 @@ pre-commit run --all-files
    ```
 
 5. **Check Licensing:** Ensure you either own the code or have the rights to use it, in accordance with the appropriate licensing.
+
+### Adding an Example
+
+Gallery examples live under `docs/examples/{graph,flow,lenet_style}/`, one script per example
+(`plot_*.py`). Sphinx-gallery auto-discovers every `plot_*.py` file in those directories - there's
+no manifest or index to update, and no separate registration step.
+
+Each script should follow the pattern of the existing examples: a module docstring explaining
+what the example demonstrates, a small model definition (or a directly imported one, e.g. from
+`torchvision`), and a call to `visualtorch.render(...)` whose output is displayed via
+`matplotlib`. Since readthedocs actually executes every example during the docs build, any new
+third-party dependency your example needs (beyond what's already installed) must be added to
+`docs/requirements.txt`.
+
+Before opening a PR, run your new example script locally to confirm it executes without error.
 
 ### Submitting Pull Requests
 


### PR DESCRIPTION
## Summary
- Fixes a few typos (missing "A", stray extra backticks).
- Adds an "Adding an Example" section explaining that gallery examples are auto-discovered by sphinx-gallery (no manifest to update), the expected script pattern, and that new example dependencies must be added to docs/requirements.txt since readthedocs actually executes every example.

Docs-only change, no version bump/release needed.