### PR TITLE
Show every output tensor's shape, not just the first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ docs/source/sg_execution_times.rst
 
 # scratch folder for previewing generated visualizations during development
 .preview/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@
 
 **Note:** `1.0+` is a major release with breaking API changes, but with significantly better features and algorithms - upgrading is recommended. For the old API, use `0.2.5` or older.
 
-**Limitation:** VisualTorch traces a real forward pass to build the diagram, which has two inherent
-limitations shared by any tracing-based approach (not bugs, and not fixable without full symbolic
-execution): (1) models with **data-dependent control flow** (e.g. a branch only taken if a tensor
-value crosses some threshold) only show whichever branch the traced dummy input happened to take;
-(2) a layer that returns **multiple meaningful output tensors** (e.g. a custom multi-task head)
-only has its first tensor's shape reflected in that node's size/label - its downstream connections
-are still correct either way. Contributions are welcome!
+**Limitation:** VisualTorch traces a real forward pass to build the diagram, which has an inherent
+limitation shared by any tracing-based approach (not a bug, and not fixable without full symbolic
+execution): models with **data-dependent control flow** (e.g. a branch only taken if a tensor
+value crosses some threshold) only show whichever branch the traced dummy input happened to take.
+Separately, a layer that returns **multiple meaningful output tensors** (e.g. a custom multi-task
+head, or `nn.LSTM`'s `(output, (h_n, c_n))`) still has its node's size based on only its first
+tensor; with `show_dimension=True`, every output tensor's shape is shown in the label, not just
+the first. Downstream connections are correct either way. Contributions are welcome!
 
 <div align="center">
 

--- a/docs/examples/graph/plot_multi_output_shapes.py
+++ b/docs/examples/graph/plot_multi_output_shapes.py
@@ -1,0 +1,58 @@
+"""Multi-Output Layer Shapes
+=======================================
+
+A leaf layer's ``forward()`` doesn't always return a single tensor - ``nn.LSTM`` returns
+``(output, (h_n, c_n))``: the full sequence of hidden states, plus the final hidden and cell
+states. With ``show_dimension=True``, every one of those output tensors' shapes is printed, not
+just the first, so a downstream layer that consumes ``h_n`` instead of ``output`` (as this model
+does) doesn't leave its actual input shape unaccounted for.
+
+LSTM is sky blue and Linear is bluish green.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class SequenceClassifier(nn.Module):
+    """A small LSTM-based classifier that reads the final hidden state, not the full sequence."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(input_size=10, hidden_size=20, batch_first=True)
+        self.fc = nn.Linear(20, 5)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the LSTM, then classify from its final hidden state (h_n), not its full sequence output."""
+        _output, (h_n, _c_n) = self.lstm(x)
+        return self.fc(h_n.squeeze(0))
+
+
+model = SequenceClassifier()
+
+input_shape = (1, 7, 10)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.LSTM]["fill"] = "#56B4E9"
+color_map[nn.Linear]["fill"] = "#009E73"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="graph",
+    show_neurons=False,
+    color_map=color_map,
+    show_dimension=True,
+    layer_spacing=100,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -11,8 +11,9 @@ import torch
 from torch import nn
 from visualtorch.backend import extract_architecture
 from visualtorch.flow import flow_view
+from visualtorch.graph import graph_view
 from visualtorch.lenet_style import lenet_view
-from visualtorch.utils.utils import self_multiply
+from visualtorch.utils.utils import format_shape_label, self_multiply
 
 
 @pytest.fixture()
@@ -112,3 +113,48 @@ def test_flow_view_recurrent_sequence_length_does_not_inflate_diagram_height(rec
     long_img = flow_view(model, input_shape=(1, 200, 10))
 
     assert long_img.height == short_img.height
+
+
+@pytest.fixture()
+def lstm_using_hidden_state_model() -> nn.Module:
+    """A model that consumes `nn.LSTM`'s hidden state (h_n), not its sequence output.
+
+    `nn.LSTM.forward()` returns `(output, (h_n, c_n))` - three tensors, not one. Before the fix,
+    only `output`'s shape was ever recorded, even when (as here) the model actually uses `h_n`
+    instead - silently dropping the shape of the tensor that matters, with nothing shown to
+    indicate more than one tensor even exists.
+    """
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lstm = nn.LSTM(input_size=10, hidden_size=20, batch_first=True)
+            self.fc = nn.Linear(20, 5)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            _output, (h_n, _c_n) = self.lstm(x)
+            return self.fc(h_n.squeeze(0))
+
+    return Model()
+
+
+def test_extract_architecture_records_every_output_tensor_shape(lstm_using_hidden_state_model: nn.Module) -> None:
+    """A multi-output leaf module's TracedLayer should record all three of its output shapes."""
+    architecture = extract_architecture(lstm_using_hidden_state_model, (1, 7, 10))
+    lstm_layer = next(layer for column in architecture.columns for layer in column if isinstance(layer.module, nn.LSTM))
+
+    assert lstm_layer.output_shape == (1, 7, 20)
+    assert lstm_layer.extra_output_shapes == ((1, 1, 20), (1, 1, 20))
+
+
+def test_format_shape_label_appends_extra_shapes() -> None:
+    """format_shape_label should append every extra shape, and omit the `+` entirely when there are none."""
+    assert format_shape_label((1, 7, 20), ()) == "(1, 7, 20)"
+    assert format_shape_label((1, 7, 20), ((1, 1, 20), (1, 1, 20))) == "(1, 7, 20) + (1, 1, 20) + (1, 1, 20)"
+
+
+@pytest.mark.parametrize("view", [graph_view, flow_view, lenet_view])
+def test_show_dimension_includes_every_output_shape(lstm_using_hidden_state_model: nn.Module, view: object) -> None:
+    """show_dimension=True shouldn't crash, and should still work, for a multi-output leaf module."""
+    img = view(lstm_using_hidden_state_model, input_shape=(1, 7, 10), show_dimension=True)  # type: ignore[operator]
+    assert img is not None

--- a/visualtorch/backend.py
+++ b/visualtorch/backend.py
@@ -67,7 +67,10 @@ def extract_architecture(model: nn.Module, input_shape: InputShape) -> Architect
     """
     input_shapes = validate_input_shape(input_shape)
 
-    id_to_module, id_to_output_shape, edges, input_ids = trace_module_graph(model, input_shapes)
+    id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids = trace_module_graph(
+        model,
+        input_shapes,
+    )
 
     nodes = list(id_to_module.keys())
     id_to_index = {node_id: idx for idx, node_id in enumerate(nodes)}
@@ -114,6 +117,7 @@ def extract_architecture(model: nn.Module, input_shape: InputShape) -> Architect
             module=id_to_module[node_id],
             output_shape=id_to_output_shape[node_id],
             node_id=node_id,
+            extra_output_shapes=id_to_extra_output_shapes.get(node_id, ()),
         )
         columns[depth[node_id]].append(wrapper)
 

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -22,6 +22,7 @@ from .utils.utils import (
     ColorWheel,
     ImageDraw,
     InputShape,
+    format_shape_label,
     get_rgba_tuple,
     linear_layout,
     self_multiply,
@@ -278,6 +279,7 @@ def _box_factory(
 
         box = Box()
         box.output_shape = tuple(ori_shape)
+        box.extra_output_shapes = layer.extra_output_shapes
         box.de = int(x / 3) if draw_volume else 0
 
         box.x1 = 0
@@ -476,7 +478,7 @@ def _draw_legend(
 
 def _column_label_and_center(column: list[VolumetricBox]) -> tuple[str, float]:
     """A column's shape label (joined across branches) and its shared x-center."""
-    label = " / ".join(str(box.output_shape) for box in column)
+    label = " / ".join(format_shape_label(box.output_shape, box.extra_output_shapes) for box in column)
     center_x = (column[0].x1 + column[0].x2) / 2
     return label, center_x
 

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -15,7 +15,7 @@ from PIL import Image, ImageFont
 from .backend import extract_architecture
 from .connectors import compute_skip_levels, draw_connector
 from .utils.traced_layer import TracedLayer
-from .utils.utils import Box, Circle, ColorWheel, Ellipses, ImageDraw, InputShape
+from .utils.utils import Box, Circle, ColorWheel, Ellipses, ImageDraw, InputShape, format_shape_label
 
 
 def graph_view(
@@ -409,7 +409,8 @@ def _create_architecture(
 
             id_to_node_list_map[layer.node_id] = layer_nodes
             nodes.extend(layer_nodes)
-            column_labels.append((str(layer.output_shape), current_x + node_size / 2, current_y))
+            label = format_shape_label(layer.output_shape, layer.extra_output_shapes)
+            column_labels.append((label, current_x + node_size / 2, current_y))
             current_y += 2 * node_size
 
         layer_y.append(current_y - node_spacing - 2 * node_size)

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -17,7 +17,15 @@ from .backend import Architecture, extract_architecture
 from .connectors import compute_skip_levels, draw_connector
 from .utils.layer_utils import Input
 from .utils.traced_layer import TracedLayer
-from .utils.utils import ColorWheel, ImageDraw, InputShape, StackedBox, get_rgba_tuple, self_multiply
+from .utils.utils import (
+    ColorWheel,
+    ImageDraw,
+    InputShape,
+    StackedBox,
+    format_shape_label,
+    get_rgba_tuple,
+    self_multiply,
+)
 
 _LABEL_ROW_HEIGHT = 100
 
@@ -266,6 +274,7 @@ def _box_factory(
         box.offset_z = offset_z
         box.label = layer.module.name() if isinstance(layer.module, Input) else layer_type.__name__
         box.output_shape = tuple(ori_shape)
+        box.extra_output_shapes = layer.extra_output_shapes
         box.de = z
 
         box.x1 = 0
@@ -405,6 +414,7 @@ def _draw_labels(
         for box in column:
             loc_x = box.x1 + (box.x2 - box.x1) // 4
             label = getattr(box, "label", type(box).__name__)
-            draw_text.text((loc_x, img.height - 50), f"{label} {box.output_shape}", font=font, fill=font_color)
+            shape_label = format_shape_label(box.output_shape, box.extra_output_shapes)
+            draw_text.text((loc_x, img.height - 50), f"{label} {shape_label}", font=font, fill=font_color)
 
     return Image.alpha_composite(img, text_img)

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -106,28 +106,34 @@ def _wrap_and_stamp(obj: Any, ids: set[str]) -> Any:
     return obj
 
 
-def _first_tensor_shape(obj: Any) -> tuple[int, ...]:
-    """Recursively find the shape of the first tensor inside obj, or () if there isn't one."""
+def _all_tensor_shapes(obj: Any) -> list[tuple[int, ...]]:
+    """Recursively collect the shape of every tensor inside obj, in encounter order.
+
+    A module's return value isn't always a single tensor - `nn.LSTM` returns
+    `(output, (h_n, c_n))`, `nn.MultiheadAttention` returns `(attn_output, attn_weights)`, and a
+    custom module can return any tuple/list/dict of tensors. Collecting all of them (rather than
+    just the first) is what lets a caller show every output shape instead of silently dropping
+    every tensor after the first.
+    """
     if isinstance(obj, torch.Tensor):
-        return tuple(obj.shape)
+        return [tuple(obj.shape)]
     if isinstance(obj, Mapping):
+        shapes = []
         for value in obj.values():
-            shape = _first_tensor_shape(value)
-            if shape:
-                return shape
-        return ()
+            shapes.extend(_all_tensor_shapes(value))
+        return shapes
     if isinstance(obj, list | tuple):
+        shapes = []
         for value in obj:
-            shape = _first_tensor_shape(value)
-            if shape:
-                return shape
-        return ()
-    return ()
+            shapes.extend(_all_tensor_shapes(value))
+        return shapes
+    return []
 
 
 def _wrapped_module_call(
     id_to_module: dict[str, nn.Module],
     id_to_output_shape: dict[str, tuple[int, ...]],
+    id_to_extra_output_shapes: dict[str, tuple[tuple[int, ...], ...]],
     edges: list[tuple[str, str]],
     call_counts: dict[int, int],
 ) -> Any:
@@ -154,8 +160,11 @@ def _wrapped_module_call(
             call_counts[base_id] = call_index + 1
             node_id = f"{base_id}#{call_index}"
 
+            shapes = _all_tensor_shapes(out)
             id_to_module[node_id] = mod
-            id_to_output_shape[node_id] = _first_tensor_shape(out)
+            id_to_output_shape[node_id] = shapes[0] if shapes else ()
+            if len(shapes) > 1:
+                id_to_extra_output_shapes[node_id] = tuple(shapes[1:])
             edges.extend((producer_id, node_id) for producer_id in producer_ids)
             out = _wrap_and_stamp(out, {node_id})
 
@@ -171,11 +180,13 @@ class Recorder:
         self,
         id_to_module: dict[str, nn.Module],
         id_to_output_shape: dict[str, tuple[int, ...]],
+        id_to_extra_output_shapes: dict[str, tuple[tuple[int, ...], ...]],
         edges: list[tuple[str, str]],
         call_counts: dict[int, int],
     ) -> None:
         self._id_to_module = id_to_module
         self._id_to_output_shape = id_to_output_shape
+        self._id_to_extra_output_shapes = id_to_extra_output_shapes
         self._edges = edges
         self._call_counts = call_counts
 
@@ -184,6 +195,7 @@ class Recorder:
         nn.Module.__call__ = _wrapped_module_call(  # type: ignore[method-assign]
             self._id_to_module,
             self._id_to_output_shape,
+            self._id_to_extra_output_shapes,
             self._edges,
             self._call_counts,
         )
@@ -197,7 +209,13 @@ class Recorder:
 def trace_module_graph(
     model: nn.Module,
     input_shapes: tuple[tuple[int, ...], ...],
-) -> tuple[dict[str, nn.Module], dict[str, tuple[int, ...]], list[tuple[str, str]], list[str]]:
+) -> tuple[
+    dict[str, nn.Module],
+    dict[str, tuple[int, ...]],
+    dict[str, tuple[tuple[int, ...], ...]],
+    list[tuple[str, str]],
+    list[str],
+]:
     """Trace a forward pass to recover the leaf-module call graph.
 
     Args:
@@ -210,7 +228,11 @@ def trace_module_graph(
         tuple: A tuple containing:
             - id_to_module (dict): Mapping from node id to the leaf module. A leaf module
                 called more than once gets one entry per call (`f"{id(module)}#{call_index}"`).
-            - id_to_output_shape (dict): Mapping from node id to that module's output shape.
+            - id_to_output_shape (dict): Mapping from node id to that module's *first* output
+                tensor's shape (the one used for box sizing).
+            - id_to_extra_output_shapes (dict): Mapping from node id to the shapes of any
+                *additional* output tensors beyond the first (e.g. `nn.LSTM`'s `(h_n, c_n)`) -
+                only present for nodes that return more than one tensor.
             - edges (list): `(producer_node_id, consumer_node_id)` pairs, in call order.
             - input_ids (list): One synthetic node id per input tensor, in the same order as
                 `input_shapes`.
@@ -223,10 +245,11 @@ def trace_module_graph(
 
     id_to_module: dict[str, nn.Module] = {}
     id_to_output_shape: dict[str, tuple[int, ...]] = {}
+    id_to_extra_output_shapes: dict[str, tuple[tuple[int, ...], ...]] = {}
     edges: list[tuple[str, str]] = []
     call_counts: dict[int, int] = {}
 
-    with Recorder(id_to_module, id_to_output_shape, edges, call_counts):
+    with Recorder(id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, call_counts):
         if isinstance(model, nn.ModuleList):
             # nn.ModuleList has no forward() of its own - it's a plain container, not meant to
             # be called directly - so drive it the same way a user would: chain each child call.
@@ -244,4 +267,4 @@ def trace_module_graph(
             model(*dummy_inputs)
 
     input_ids = [f"{INPUT_NODE_ID}#{i}" for i in range(len(input_shapes))]
-    return id_to_module, id_to_output_shape, edges, input_ids
+    return id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids

--- a/visualtorch/utils/traced_layer.py
+++ b/visualtorch/utils/traced_layer.py
@@ -20,3 +20,9 @@ class TracedLayer:
     module: nn.Module
     output_shape: tuple[int, ...]
     node_id: str
+    extra_output_shapes: tuple[tuple[int, ...], ...] = ()
+    """Shapes of any additional output tensors beyond `output_shape` (e.g. `nn.LSTM`'s hidden and
+    cell state, returned alongside its main sequence output) - empty for a module that returns
+    just one tensor. `output_shape` alone still drives box sizing; this is only ever read to
+    extend the `show_dimension` label so those extra tensors aren't silently unaccounted for.
+    """

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -66,6 +66,7 @@ class StackedBox(Shape):
     offset_z: int
     label: str
     output_shape: tuple
+    extra_output_shapes: tuple[tuple[int, ...], ...] = ()
 
     def draw(self, draw: ImageDraw) -> None:
         """Draw box shape."""
@@ -114,6 +115,7 @@ class Box(Shape):
     de: int
     shade: int
     output_shape: tuple[int, ...]
+    extra_output_shapes: tuple[tuple[int, ...], ...] = ()
 
     def draw(self, draw: ImageDraw) -> None:
         """Draw box shape."""
@@ -342,6 +344,22 @@ def self_multiply(tensor_tuple: tuple | list) -> int | float:
     for v in tensor_list:
         s *= self_multiply(v) if isinstance(v, tuple | list) else v
     return s
+
+
+def format_shape_label(output_shape: tuple[int, ...], extra_output_shapes: tuple[tuple[int, ...], ...]) -> str:
+    """Format an output shape for display, appending any extra output shapes if present.
+
+    A module that returns more than one meaningful tensor (e.g. `nn.LSTM`'s `(output, (h_n,
+    c_n))`) would otherwise only ever show `output_shape` (the first tensor found, also the one
+    driving box size) with no indication the other tensors exist at all. `+` is used rather than
+    `visualtorch`'s existing `/` convention (already used to join sibling branches within one
+    column) so this doesn't read as an alternative/branch - these are all real outputs of this
+    same node, not one of several options.
+    """
+    label = str(output_shape)
+    if extra_output_shapes:
+        label += " + " + " + ".join(str(shape) for shape in extra_output_shapes)
+    return label
 
 
 def vertical_image_concat(


### PR DESCRIPTION
## Summary
- A leaf module returning multiple meaningful tensors (e.g. `nn.LSTM`'s `(output, (h_n, c_n))`) previously only had its first tensor's shape recorded anywhere, silently dropping the others - misleading whenever a model actually consumes a tensor other than the first (e.g. using `h_n` instead of `output`).
- The tracer (`recorder.py`) now records every output tensor's shape found in a leaf module's return value, not just the first.
- `show_dimension=True` now displays all of them, e.g. `(1, 7, 20) + (1, 1, 20) + (1, 1, 20)`, across `graph`/`flow`/`lenet` styles alike.
- Box **sizing** is intentionally left driven by the first tensor only - which tensor "should" size the box is genuinely ambiguous when a node feeds multiple different consumers each using a different one of its output tensors, so this only fixes the silently-dropped-information part, not sizing.
- Updates the README's limitation note to reflect this, and adds `.DS_Store` to `.gitignore`.

## Test plan
- [x] `pytest tests/` - 113 passed (5 new tests covering the tracer, the `format_shape_label` helper, and all three render styles)
- [x] `pre-commit run --all-files` - clean (run twice)
- [x] Manually rendered an `nn.LSTM`-using model in all three styles and visually confirmed all three output shapes now show