### PR TITLE
Fix Research Showcase page title duplicating its own sidebar caption

### DIFF
--- a/docs/source/markdown/showcase/index.md
+++ b/docs/source/markdown/showcase/index.md
@@ -1,6 +1,7 @@
-# Research Showcase
+# Papers Using VisualTorch
 
-Published research that has used VisualTorch to visualize model architectures.
+Published research that has used VisualTorch to visualize model architectures. Used it in your
+own research? [Open a pull request](https://github.com/willyfh/visualtorch/pulls) to add it here.
 
 | Paper                                                                                                                                                                                                                                                                                     | Venue (Year)                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
@@ -51,7 +52,3 @@ Trains a CNN on physics-based finite element simulations to predict equivalent p
 for use in structural digital twins.
 
 ![CNN architecture](../../_static/images/showcase/mdpi-shear-wall.png)
-
----
-
-Used VisualTorch in your own research? [Open a pull request](https://github.com/willyfh/visualtorch/pulls) to add it here.


### PR DESCRIPTION
## Summary
- The showcase page's own `# H1` was worded identically to the toctree `:caption:` that groups it in the sidebar nav, so "Research Showcase" showed up twice back to back.
- Renamed the page title to "Papers Using VisualTorch" - distinct from the caption, and more precise (it's specifically research papers, not a general showcase).
- Moved the "used it in your research? open a PR" call-to-action from the bottom of the page to the top, so it's visible immediately rather than after scrolling past all existing entries.

Docs-only change, no version bump/release needed.