### PR TITLE
Backfill missing example topics across graph/flow/lenet_style

### DIFF
--- a/docs/examples/flow/plot_multi_output_shapes_flow.py
+++ b/docs/examples/flow/plot_multi_output_shapes_flow.py
@@ -1,0 +1,57 @@
+"""Multi-Output Layer Shapes
+=======================================
+
+A leaf layer's ``forward()`` doesn't always return a single tensor - ``nn.LSTM`` returns
+``(output, (h_n, c_n))``: the full sequence of hidden states, plus the final hidden and cell
+states. With ``show_dimension=True``, every one of those output tensors' shapes is printed, not
+just the first, so a downstream layer that consumes ``h_n`` instead of ``output`` (as this model
+does) doesn't leave its actual input shape unaccounted for.
+
+LSTM is sky blue and Linear is bluish green.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class SequenceClassifier(nn.Module):
+    """A small LSTM-based classifier that reads the final hidden state, not the full sequence."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(input_size=64, hidden_size=128, batch_first=True)
+        self.fc = nn.Linear(128, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the LSTM, then classify from its final hidden state (h_n), not its full sequence output."""
+        _output, (h_n, _c_n) = self.lstm(x)
+        return self.fc(h_n.squeeze(0))
+
+
+model = SequenceClassifier()
+
+input_shape = (1, 7, 64)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.LSTM]["fill"] = "#56B4E9"
+color_map[nn.Linear]["fill"] = "#009E73"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="flow",
+    color_map=color_map,
+    show_dimension=True,
+    spacing=60,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/graph/plot_custom_opacity_graph.py
+++ b/docs/examples/graph/plot_custom_opacity_graph.py
@@ -1,0 +1,44 @@
+"""Custom Opacity
+=======================================
+
+Change the color transparency
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+input_shape = (1, 3, 224, 224)
+
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="graph",
+    show_neurons=False,
+    layer_spacing=60,
+    opacity=100,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/graph/plot_dark_background_graph.py
+++ b/docs/examples/graph/plot_dark_background_graph.py
@@ -1,0 +1,53 @@
+"""Dark Background
+=======================================
+
+``background_fill`` isn't limited to plain white - it also accepts a transparent color
+(e.g. ``(0, 0, 0, 0)``), useful for dropping a figure onto a paper/slide without a white box
+around it, or an opaque dark color for a nicer look on dark-mode pages.
+
+Note: when using a non-white background, also set an ``outline`` per layer type in
+``color_map``, and ``connector_fill`` for the lines between nodes. Both default to plain black,
+which becomes invisible against a dark or black background.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.BatchNorm2d(16),
+    nn.ReLU(),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.BatchNorm2d(32),
+    nn.ReLU(),
+)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#00F5FF"
+color_map[nn.Conv2d]["outline"] = "#E0FFFF"
+color_map[nn.BatchNorm2d]["fill"] = "#FF10F0"
+color_map[nn.BatchNorm2d]["outline"] = "#FFD1FA"
+color_map[nn.ReLU]["fill"] = "#FCEE09"
+color_map[nn.ReLU]["outline"] = "#FFFACD"
+
+input_shape = (1, 3, 32, 32)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="graph",
+    show_neurons=False,
+    color_map=color_map,
+    connector_fill="white",
+    background_fill="black",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_basic_custom_lenet_style.py
+++ b/docs/examples/lenet_style/plot_basic_custom_lenet_style.py
@@ -1,0 +1,55 @@
+"""Basic Custom
+=======================================
+
+Visualization of basic custom model
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import torch
+import torch.nn.functional as func
+import visualtorch
+from torch import nn
+
+
+# Example of a simple CNN model
+class SimpleCNN(nn.Module):
+    """Simple CNN Model."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, padding=1)
+        self.conv3 = nn.Conv2d(32, 64, kernel_size=3, padding=1)
+        self.fc1 = nn.Linear(64 * 28 * 28, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass."""
+        x = self.conv1(x)
+        x = func.relu(x)
+        x = func.max_pool2d(x, 2, 2)
+        x = self.conv2(x)
+        x = func.relu(x)
+        x = func.max_pool2d(x, 2, 2)
+        x = self.conv3(x)
+        x = func.relu(x)
+        x = func.max_pool2d(x, 2, 2)
+        x = x.view(x.size(0), -1)
+        x = self.fc1(x)
+        x = func.relu(x)
+        return self.fc2(x)
+
+
+# Create an instance of the SimpleCNN
+model = SimpleCNN()
+
+input_shape = (1, 3, 224, 224)
+
+img = visualtorch.render(model, input_shape=input_shape, style="lenet")
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_color_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_color_lenet_style.py
@@ -1,0 +1,49 @@
+"""Custom Color
+=======================================
+
+Visualization of custom color. The synthetic input box can be recolored too, keyed by
+``visualtorch.Input`` in ``color_map`` just like any real layer type - left
+uncustomized, it would default to the same color as ``Conv2d`` here, since both would otherwise
+claim the same slot in the color wheel.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+color_map: dict = defaultdict(dict)
+color_map[visualtorch.Input]["fill"] = "#D55E00"  # vermillion
+color_map[nn.Conv2d]["fill"] = "#E69F00"  # orange
+color_map[nn.ReLU]["fill"] = "#56B4E9"  # sky blue
+color_map[nn.MaxPool2d]["fill"] = "#CC79A7"  # reddish purple
+color_map[nn.Flatten]["fill"] = "#009E73"  # bluish green
+color_map[nn.Linear]["fill"] = "#0072B2"  # blue
+
+input_shape = (1, 3, 224, 224)
+img = visualtorch.render(model, input_shape=input_shape, style="lenet", color_map=color_map)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_opacity_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_opacity_lenet_style.py
@@ -1,0 +1,37 @@
+"""Custom Opacity
+=======================================
+
+Change the color transparency
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+input_shape = (1, 3, 224, 224)
+
+img = visualtorch.render(model, input_shape=input_shape, style="lenet", opacity=100)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_orientation_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_orientation_lenet_style.py
@@ -1,0 +1,43 @@
+"""Custom Orientation
+=======================================
+
+Visualization of custom orientation for 1 dim layers
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+input_shape = (1, 3, 224, 224)
+
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+    one_dim_orientation="x",
+    spacing=40,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_shading_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_shading_lenet_style.py
@@ -1,0 +1,36 @@
+"""Custom Shading
+=======================================
+
+Visualization of custom shading
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+input_shape = (1, 3, 224, 224)
+img = visualtorch.render(model, input_shape=input_shape, style="lenet", shade_step=50)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_spacing_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_spacing_lenet_style.py
@@ -1,0 +1,37 @@
+"""Custom Spacing
+=======================================
+
+Visualization of custom spacing
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+input_shape = (1, 3, 224, 224)
+
+img = visualtorch.render(model, input_shape=input_shape, style="lenet", spacing=50)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_dark_background_lenet_style.py
+++ b/docs/examples/lenet_style/plot_dark_background_lenet_style.py
@@ -1,0 +1,51 @@
+"""Dark Background
+=======================================
+
+``background_fill`` isn't limited to plain white - it also accepts a transparent color
+(e.g. ``(0, 0, 0, 0)``), useful for dropping a figure onto a paper/slide without a white box
+around it, or an opaque dark color for a nicer look on dark-mode pages.
+
+Note: when using a non-white background, also set an ``outline`` per layer type in
+``color_map``. Box borders default to plain black, which becomes invisible against a dark or
+black background.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.BatchNorm2d(16),
+    nn.ReLU(),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.BatchNorm2d(32),
+    nn.ReLU(),
+)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#00F5FF"
+color_map[nn.Conv2d]["outline"] = "#E0FFFF"
+color_map[nn.BatchNorm2d]["fill"] = "#FF10F0"
+color_map[nn.BatchNorm2d]["outline"] = "#FFD1FA"
+color_map[nn.ReLU]["fill"] = "#FCEE09"
+color_map[nn.ReLU]["outline"] = "#FFFACD"
+
+input_shape = (1, 3, 32, 32)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+    color_map=color_map,
+    background_fill="black",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_ignore_layers_lenet_style.py
+++ b/docs/examples/lenet_style/plot_ignore_layers_lenet_style.py
@@ -1,0 +1,46 @@
+"""Ignore Layers
+=======================================
+
+Visualize some layers only. ``type_ignore`` hides layer types you don't care about (here, ReLU
+and Flatten); ``show_input=False`` is the same idea applied to the synthetic input box itself -
+both trim the diagram down to just the layers worth looking at.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+# Example of a simple CNN model using nn.Sequential
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(64 * 28 * 28, 256),  # Adjusted the input size for the Linear layer
+    nn.ReLU(),
+    nn.Linear(256, 10),  # Assuming 10 output classes
+)
+
+ignored_layers = [nn.ReLU, nn.Flatten]
+
+input_shape = (1, 3, 224, 224)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+    type_ignore=ignored_layers,
+    show_input=False,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_multi_output_shapes_lenet_style.py
+++ b/docs/examples/lenet_style/plot_multi_output_shapes_lenet_style.py
@@ -1,0 +1,62 @@
+"""Multi-Output Layer Shapes
+=======================================
+
+A leaf layer's ``forward()`` doesn't always return a single tensor - ``nn.LSTM`` returns
+``(output, (h_n, c_n))``: the full sequence of hidden states, plus the final hidden and cell
+states. ``show_dimension`` defaults to ``True`` for this style, and every one of those output
+tensors' shapes is printed, not just the first, so a downstream layer that consumes ``h_n``
+instead of ``output`` (as this model does) doesn't leave its actual input shape unaccounted for.
+
+``one_dim_orientation="x"`` is set here since the default (``"z"``) stacks a 1D layer's units as
+individual depth slices - fine for a small unit count, but the ``Linear`` layer's 10 output units
+would otherwise draw as a tall staircase of thin slices instead of a single block.
+
+LSTM is sky blue and Linear is bluish green.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class SequenceClassifier(nn.Module):
+    """A small LSTM-based classifier that reads the final hidden state, not the full sequence."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(input_size=64, hidden_size=128, batch_first=True)
+        self.fc = nn.Linear(128, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the LSTM, then classify from its final hidden state (h_n), not its full sequence output."""
+        _output, (h_n, _c_n) = self.lstm(x)
+        return self.fc(h_n.squeeze(0))
+
+
+model = SequenceClassifier()
+
+input_shape = (1, 7, 64)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.LSTM]["fill"] = "#56B4E9"
+color_map[nn.Linear]["fill"] = "#009E73"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="lenet",
+    color_map=color_map,
+    spacing=250,
+    padding=60,
+    one_dim_orientation="x",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_resnet18_lenet_style.py
+++ b/docs/examples/lenet_style/plot_resnet18_lenet_style.py
@@ -1,0 +1,38 @@
+"""ResNet-18
+=======================================
+
+The same real, torchvision-provided `resnet18` architecture as the ``graph``/``flow`` styles'
+examples - 8 residual blocks across 4 stages, with a projection shortcut where channels/spatial
+size change - rendered in ``lenet`` style instead.
+
+Note: ``offset_z`` (the per-slice depth offset used for the stacked-plane 3D look) defaults to
+``10``, tuned for small toy models - for a real model with channel counts in the hundreds, that
+default multiplies into an enormous image, so it's lowered here to ``1``.
+
+Conv2d is orange, BatchNorm2d is green, and ReLU is sky blue.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+from torchvision.models import resnet18
+
+model = resnet18(weights=None, num_classes=10)
+
+input_shape = (1, 3, 64, 64)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.BatchNorm2d]["fill"] = "#009E73"
+color_map[nn.ReLU]["fill"] = "#56B4E9"
+
+img = visualtorch.render(model, input_shape, style="lenet", color_map=color_map, offset_z=1, spacing=10)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_unet_lenet_style.py
+++ b/docs/examples/lenet_style/plot_unet_lenet_style.py
@@ -1,0 +1,64 @@
+"""U-Net
+=======================================
+
+The same small U-Net as the ``graph``/``flow`` styles' examples, rendered in ``lenet`` style
+instead - the contracting-then-expanding channel/spatial shape naturally produces the classic
+U-Net silhouette.
+
+Conv2d is orange, ConvTranspose2d is green, ReLU is sky blue, and MaxPool2d is reddish purple.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class UNet(nn.Module):
+    """A small U-Net with 2 encoder/decoder stages and skip connections."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.enc1 = nn.Sequential(nn.Conv2d(3, 16, kernel_size=3, padding=1), nn.ReLU())
+        self.pool1 = nn.MaxPool2d(2)
+        self.enc2 = nn.Sequential(nn.Conv2d(16, 32, kernel_size=3, padding=1), nn.ReLU())
+        self.pool2 = nn.MaxPool2d(2)
+        self.bottleneck = nn.Sequential(nn.Conv2d(32, 64, kernel_size=3, padding=1), nn.ReLU())
+        self.up2 = nn.ConvTranspose2d(64, 32, kernel_size=2, stride=2)
+        self.dec2 = nn.Sequential(nn.Conv2d(64, 32, kernel_size=3, padding=1), nn.ReLU())
+        self.up1 = nn.ConvTranspose2d(32, 16, kernel_size=2, stride=2)
+        self.dec1 = nn.Sequential(nn.Conv2d(32, 16, kernel_size=3, padding=1), nn.ReLU())
+        self.final = nn.Conv2d(16, 2, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Downsample through 2 encoder stages, then upsample back, concatenating each
+        encoder stage's output into its corresponding decoder stage.
+        """  # noqa: D205
+        e1 = self.enc1(x)
+        e2 = self.enc2(self.pool1(e1))
+        b = self.bottleneck(self.pool2(e2))
+        d2 = self.dec2(torch.cat([self.up2(b), e2], dim=1))
+        d1 = self.dec1(torch.cat([self.up1(d2), e1], dim=1))
+        return self.final(d1)
+
+
+model = UNet()
+
+input_shape = (1, 3, 64, 64)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.ConvTranspose2d]["fill"] = "#009E73"
+color_map[nn.ReLU]["fill"] = "#56B4E9"
+color_map[nn.MaxPool2d]["fill"] = "#CC79A7"
+
+img = visualtorch.render(model, input_shape, style="lenet", color_map=color_map, spacing=25)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_vit_lenet_style.py
+++ b/docs/examples/lenet_style/plot_vit_lenet_style.py
@@ -1,0 +1,82 @@
+"""Vision Transformer (ViT)
+=======================================
+
+The same small Vision Transformer as the ``graph``/``flow`` styles' ViT examples, rendered in
+``lenet`` style instead. This style's "stacked 3D plane" look is built around CNN feature maps,
+so it doesn't translate cleanly to a Transformer's ``(batch, seq_len, dim)`` shapes - included
+here for completeness, but ``graph`` is the clearer choice for this kind of architecture.
+
+Note: VisualTorch traces the literal module-by-module computation, so this shows the real
+executed sequence of layers, not the conceptual/pedagogical diagram style used in ViT papers.
+``show_dimension`` (on by default for this style) is turned off here - with this many
+similarly-narrow boxes packed close together, the shape labels overlap into an unreadable mess.
+
+Conv2d is orange, MultiheadAttention is reddish purple, Linear is sky blue, LayerNorm is bluish
+green, and Dropout is yellow.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class VisionTransformer(nn.Module):
+    """A small Vision Transformer: patch embedding + positional embedding + Transformer encoder."""
+
+    def __init__(
+        self,
+        img_size: int = 32,
+        patch_size: int = 8,
+        dim: int = 64,
+        depth: int = 2,
+        heads: int = 4,
+        num_classes: int = 10,
+    ) -> None:
+        super().__init__()
+        num_patches = (img_size // patch_size) ** 2
+        self.patch_embed = nn.Conv2d(3, dim, kernel_size=patch_size, stride=patch_size)
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, dim))
+        encoder_layer = nn.TransformerEncoderLayer(d_model=dim, nhead=heads, dim_feedforward=dim * 4, batch_first=True)
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=depth)
+        self.head = nn.Linear(dim, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Split into patches, embed, add positional embedding, encode, then classify."""
+        x = self.patch_embed(x)
+        x = x.flatten(2).transpose(1, 2)
+        x = x + self.pos_embed
+        x = self.encoder(x)
+        x = x.mean(dim=1)
+        return self.head(x)
+
+
+model = VisionTransformer()
+
+input_shape = (1, 3, 32, 32)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.MultiheadAttention]["fill"] = "#CC79A7"
+color_map[nn.Linear]["fill"] = "#56B4E9"
+color_map[nn.LayerNorm]["fill"] = "#009E73"
+color_map[nn.Dropout]["fill"] = "#F0E442"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="lenet",
+    color_map=color_map,
+    spacing=80,
+    padding=60,
+    show_dimension=False,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
## Summary
Comparing `docs/examples/{graph,flow,lenet_style}/` topic-by-topic surfaced 15 gaps where a topic exists for one or two styles but was missing for a style whose `render()` signature genuinely supports it:

- **lenet_style/** (12 files): `basic_custom`, `custom_color`, `custom_spacing`, `custom_opacity`, `custom_orientation`, `custom_shading`, `dark_background`, `ignore_layers`, `multi_output_shapes`, `resnet18`, `unet`, `vit`
- **graph/** (2 files): `custom_opacity`, `dark_background`
- **flow/** (1 file): `multi_output_shapes`

Each was adapted from the existing per-topic template for another style, with per-file tuning where lenet_style's channel-count-driven box sizing needed different defaults - most notably `offset_z` for ResNet-18 (default `offset_z=10` combined with channel counts up to 512 blew up the image to ~50000px wide; lowered to `1`). The ViT and LSTM (`multi_output_shapes`) lenet_style examples include an honest docstring caveat that this style's "stacked 3D plane" look is built around CNN feature maps and doesn't translate cleanly to Transformer/RNN-shaped tensors - included for topic parity, not because the visual result is as clean as the CNN showcase examples.

Note: a real, separate issue surfaced while building the ViT/LSTM lenet examples - 1D and 2D tensor shapes get inconsistent visual treatment in `flow.py`/`lenet_style.py`'s shared box-building logic (1D shapes stack as z-slices by default, 2D shapes are explicitly flattened to avoid that same stacking) - deliberately left out of this PR since it touches shared rendering code and would likely shift the default look of many existing examples. Filed as a follow-up.

## Test plan
- [x] All 15 new example files run standalone with no exceptions
- [x] `pytest tests/` - 127 passed (no runtime code touched, docs-only change)
- [x] `pre-commit run --all-files` passes (twice consecutively)
- [x] Visually verified renders for the trickier cases (ResNet-18, U-Net, ViT, multi_output_shapes) via `.preview/`