### PR TITLE
Bump version to 1.2.0, fix README banner on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the first. Downstream connections are correct either way. Contributions are welc
 
 <div align="center">
 
-![VisualTorch Examples](docs/source/_static/images/banners/readme-examples.png)
+![VisualTorch Examples](https://raw.githubusercontent.com/willyfh/visualtorch/e6ad79751e0f7412b1074beb45f9baeccd1419e4/docs/source/_static/images/banners/readme-examples.png)
 
 </div>
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="1.1.0",
+    version="1.2.0",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     description="Architecture visualization of Torch models",


### PR DESCRIPTION
## Summary
- Bump `setup.py` version to `1.2.0`, prepping for the next release (covers PR #99, #102, #104 since v1.1.0 - see changelog discussion for full list).
- Fix the README banner image not showing up on PyPI - the path was relative (`docs/source/_static/images/banners/readme-examples.png`), which resolves fine on GitHub but not in PyPI's rendered long description. Switched to an absolute `raw.githubusercontent.com` URL pinned to a specific commit SHA (rather than `main`) so it won't silently change on older PyPI package pages later.

## Test plan
- [x] Verified the new image URL resolves (`curl -I` returns 200)
- [x] `pytest tests/` passes
- [x] `pre-commit run --all-files` passes