### PR TITLE
Update pip install version snippet to 1.2.0

### DIFF
--- a/docs/source/snippets/install/pypi.txt
+++ b/docs/source/snippets/install/pypi.txt
@@ -1,1 +1,1 @@
-pip install visualtorch==1.1.0
+pip install visualtorch==1.2.0


### PR DESCRIPTION
## Summary
- The Installation docs page's `pip install visualtorch==X.Y.Z` snippet was still pinned to `1.1.0`, missed during the `1.2.0` version bump PR (#105).

## Test plan
- [x] `pre-commit run --all-files` passes