### PR TITLE
Add deprecation shims for renamed API

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn.functional as func
 from PIL import Image
 from torch import nn
-from visualtorch.flow import flow_view
+from visualtorch.flow import flow_view, layered_view
 
 
 @pytest.fixture()
@@ -184,6 +184,14 @@ def test_flow_view_invalid_low_dim_orientation_raises(classifier_model: nn.Modul
     """An unsupported low_dim_orientation should raise a clear ValueError."""
     with pytest.raises(ValueError, match="unsupported orientation"):
         flow_view(classifier_model, input_shape=(1, 3, 16, 16), low_dim_orientation="bad")
+
+
+def test_flow_view_one_dim_orientation_still_works(classifier_model: nn.Module) -> None:
+    """The deprecated one_dim_orientation kwarg should still work and warn, not crash."""
+    with pytest.warns(DeprecationWarning, match="one_dim_orientation"):
+        deprecated_img = flow_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation="x")
+    current_img = flow_view(classifier_model, input_shape=(1, 3, 16, 16), low_dim_orientation="x")
+    assert deprecated_img.tobytes() == current_img.tobytes()
 
 
 def test_flow_view_with_type_ignore(sequential_model: nn.Sequential) -> None:
@@ -586,3 +594,18 @@ def test_flow_view_2d_shape_seq_len_is_discarded() -> None:
     img_bigger_hidden = flow_view(model_bigger_hidden, input_shape=(1, 5, 8))
 
     assert img_short_seq.tobytes() != img_bigger_hidden.tobytes()
+
+
+def test_layered_view_still_works(sequential_model: nn.Sequential) -> None:
+    """The deprecated layered_view should still work, warn, and match flow_view's output."""
+    with pytest.warns(DeprecationWarning, match="layered_view"):
+        deprecated_img = layered_view(sequential_model, input_shape=(1, 3, 224, 224))
+    current_img = flow_view(sequential_model, input_shape=(1, 3, 224, 224))
+    assert deprecated_img.tobytes() == current_img.tobytes()
+
+
+def test_layered_view_drops_index_ignore(sequential_model: nn.Sequential) -> None:
+    """The removed index_ignore kwarg should be silently accepted, not raise."""
+    with pytest.warns(DeprecationWarning, match="layered_view"):
+        img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), index_ignore=[0])
+    assert img is not None

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -186,6 +186,14 @@ def test_lenet_view_invalid_low_dim_orientation_raises(classifier_model: nn.Modu
         lenet_view(classifier_model, input_shape=(1, 3, 16, 16), low_dim_orientation="bad")
 
 
+def test_lenet_view_one_dim_orientation_still_works(classifier_model: nn.Module) -> None:
+    """The deprecated one_dim_orientation kwarg should still work and warn, not crash."""
+    with pytest.warns(DeprecationWarning, match="one_dim_orientation"):
+        deprecated_img = lenet_view(classifier_model, input_shape=(1, 3, 16, 16), one_dim_orientation="x")
+    current_img = lenet_view(classifier_model, input_shape=(1, 3, 16, 16), low_dim_orientation="x")
+    assert deprecated_img.tobytes() == current_img.tobytes()
+
+
 def test_lenet_view_with_type_ignore(sequential_model: nn.Sequential) -> None:
     """Layers matched by type_ignore should be skipped without error."""
     img = lenet_view(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -192,3 +192,34 @@ def test_render_color_map_overrides_palette(sequential_model: nn.Sequential) -> 
     )
 
     assert okabe_ito.tobytes() == dracula.tobytes()
+
+
+def test_input_dummy_layer_alias_still_works() -> None:
+    """The deprecated top-level InputDummyLayer alias should still resolve to Input and warn."""
+    import visualtorch
+
+    with pytest.warns(DeprecationWarning, match="InputDummyLayer"):
+        legacy_cls = visualtorch.InputDummyLayer
+    assert legacy_cls is Input
+
+
+def test_input_dummy_layer_alias_from_layer_utils_still_works() -> None:
+    """The deprecated InputDummyLayer alias should also resolve via its original submodule path."""
+    from visualtorch.utils import layer_utils
+
+    with pytest.warns(DeprecationWarning, match="InputDummyLayer"):
+        legacy_cls = layer_utils.InputDummyLayer
+    assert legacy_cls is Input
+
+
+def test_render_one_dim_orientation_still_works(sequential_model: nn.Sequential) -> None:
+    """The deprecated one_dim_orientation kwarg should still work through render() for both styles."""
+    with pytest.warns(DeprecationWarning, match="one_dim_orientation"):
+        flow_deprecated = render(sequential_model, input_shape=(1, 3, 16, 16), style="flow", one_dim_orientation="x")
+    flow_current = render(sequential_model, input_shape=(1, 3, 16, 16), style="flow", low_dim_orientation="x")
+    assert flow_deprecated.tobytes() == flow_current.tobytes()
+
+    with pytest.warns(DeprecationWarning, match="one_dim_orientation"):
+        lenet_deprecated = render(sequential_model, input_shape=(1, 3, 16, 16), style="lenet", one_dim_orientation="x")
+    lenet_current = render(sequential_model, input_shape=(1, 3, 16, 16), style="lenet", low_dim_orientation="x")
+    assert lenet_deprecated.tobytes() == lenet_current.tobytes()

--- a/visualtorch/__init__.py
+++ b/visualtorch/__init__.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+import warnings
+
+from visualtorch.flow import layered_view  # noqa: F401 - deprecated re-export, not in __all__
 from visualtorch.render import (
     CommonOptions,
     FlowStyleOptions,
@@ -22,3 +25,17 @@ __all__ = [
     "Input",
     "PALETTES",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily provide `InputDummyLayer`, the pre-1.1 name for `Input`, with a deprecation warning."""
+    if name == "InputDummyLayer":
+        warnings.warn(
+            "`visualtorch.InputDummyLayer` is deprecated and will be removed in a future "
+            "release, use `visualtorch.Input` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Input
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from math import ceil
@@ -58,6 +59,7 @@ def flow_view(
     show_dimension: bool = False,
     level_gap: int | None = None,
     show_input: bool = True,
+    one_dim_orientation: str | None = None,
 ) -> PIL.Image:
     """Generate a flow-style architecture visualization for a given torch model.
 
@@ -104,10 +106,20 @@ def flow_view(
             you're overlaying your own custom input illustration instead. Has no effect on a
             multi-input model, where every input is always shown (omitting any of them would
             make it ambiguous which arrow belongs to which named input).
+        one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
     """
+    if one_dim_orientation is not None:
+        warnings.warn(
+            "`one_dim_orientation` is deprecated and will be removed in a future release, "
+            "use `low_dim_orientation` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        low_dim_orientation = one_dim_orientation
+
     if type_ignore is None:
         type_ignore = []
 
@@ -569,3 +581,26 @@ def _draw_dimension_labels(
         draw_text.text((center_x - text_width / 2, diagram_height + 2), label, font=font, fill=font_color)
 
     return Image.alpha_composite(img, text_img)
+
+
+def layered_view(*args: object, **kwargs: object) -> PIL.Image:
+    """Pre-1.0 alias for `flow_view`.
+
+    Accepts the same arguments as `flow_view`, plus the removed `index_ignore` (silently
+    dropped - it has no equivalent under the topology-based layout) and the renamed
+    `one_dim_orientation` (mapped to `low_dim_orientation`). Positional calls using the old
+    pre-1.0 argument order (which had `index_ignore` where `flow_view` now has `color_map`)
+    will not be translated correctly - use keyword arguments to migrate safely.
+
+    Deprecated:
+        Since version 1.0.0. Use `flow_view` instead.
+    """
+    warnings.warn(
+        "`layered_view` is deprecated and will be removed in a future release, use `flow_view` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    kwargs.pop("index_ignore", None)
+    if "one_dim_orientation" in kwargs:
+        kwargs["low_dim_orientation"] = kwargs.pop("one_dim_orientation")
+    return flow_view(*args, **kwargs)  # type: ignore[arg-type]

--- a/visualtorch/layered.py
+++ b/visualtorch/layered.py
@@ -1,0 +1,8 @@
+"""Deprecated pre-1.0 module path - `layered_view` now lives in `flow.py` as `flow_view`."""
+
+# Copyright (C) 2024 Willy Fitra Hendria
+# SPDX-License-Identifier: MIT
+
+from .flow import layered_view
+
+__all__ = ["layered_view"]

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from math import ceil
@@ -57,6 +58,7 @@ def lenet_view(
     level_gap: int | None = None,
     show_dimension: bool = True,
     show_input: bool = True,
+    one_dim_orientation: str | None = None,
 ) -> PIL.Image:
     """Generate a LeNet style architecture visualization for a given torch model.
 
@@ -108,10 +110,20 @@ def lenet_view(
             arrow belongs to which named input). Ignored (input always kept) when the input feeds
             more than one consumer, e.g. a residual shortcut, since dropping it would silently
             discard that edge.
+        one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
     """
+    if one_dim_orientation is not None:
+        warnings.warn(
+            "`one_dim_orientation` is deprecated and will be removed in a future release, "
+            "use `low_dim_orientation` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        low_dim_orientation = one_dim_orientation
+
     if type_ignore is None:
         type_ignore = []
 

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -75,6 +75,7 @@ class FlowStyleOptions:
     legend: bool = False
     show_dimension: bool = False
     show_input: bool = True
+    one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
 
 
 @dataclass
@@ -95,6 +96,7 @@ class LenetStyleOptions:
     offset_z: int = 10
     show_dimension: bool = True
     show_input: bool = True
+    one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
 
 
 def _render_graph(
@@ -160,6 +162,7 @@ def _render_flow(
         show_dimension=options.show_dimension,
         level_gap=common.level_gap,
         show_input=options.show_input,
+        one_dim_orientation=options.one_dim_orientation,
     )
 
 
@@ -195,6 +198,7 @@ def _render_lenet(
         level_gap=common.level_gap,
         show_dimension=options.show_dimension,
         show_input=options.show_input,
+        one_dim_orientation=options.one_dim_orientation,
     )
 
 

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -4,6 +4,8 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
+import warnings
+
 
 class Input:
     """A placeholder standing in for the raw input tensor, before any real computation."""
@@ -16,3 +18,16 @@ class Input:
     def name(self) -> str:
         """Return layer name"""
         return self._name
+
+
+def __getattr__(name: str) -> object:
+    """Lazily provide `InputDummyLayer`, the pre-1.1 name for `Input`, with a deprecation warning."""
+    if name == "InputDummyLayer":
+        warnings.warn(
+            "`InputDummyLayer` is deprecated and will be removed in a future release, use `Input` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Input
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)


### PR DESCRIPTION
## Summary
- A YouTube tutorial covering VisualTorch turned out to break entirely on current `main`, since it predates several renames that had no backward-compatible alias: `layered_view` (pre-1.0), `InputDummyLayer` (pre-1.1), and `one_dim_orientation` (pre-1.2) all hit hard errors instead of just being outdated-but-working.
- `layered_view()`: deprecated wrapper forwarding to `flow_view`, dropping the removed `index_ignore` and mapping `one_dim_orientation`→`low_dim_orientation`. Also restores the `visualtorch.layered` module path and top-level `visualtorch.layered_view` import.
- `InputDummyLayer`: lazily resolved via module-level `__getattr__` (both `visualtorch.InputDummyLayer` and `visualtorch.utils.layer_utils.InputDummyLayer`), returning `Input` with a `DeprecationWarning`.
- `one_dim_orientation`: restored as a deprecated kwarg on `flow_view`/`lenet_view` (and threaded through `render()`'s `FlowStyleOptions`/`LenetStyleOptions`), mapped to `low_dim_orientation` with a warning.
- None of this changes current (`low_dim_orientation`-based) behavior - purely additive compatibility for old callers.

Deliberately **not** touched: `layered_view`'s pre-1.0 signature isn't faithfully replicated (positional calls using the old argument order, which had `index_ignore` where `flow_view` now has `color_map`, won't translate correctly) - only keyword-argument usage is guaranteed to keep working. This was a deliberate scope decision: the goal is "don't crash," not "identical old behavior."

## Test plan
- [x] `pre-commit run --all-files` passes (x2 in a row)
- [x] Full test suite passes (138/138, 7 new tests covering all four cases)
- [x] Manually verified end-to-end: `layered_view` + `index_ignore`, `InputDummyLayer` (both import paths), `one_dim_orientation` on `flow_view`/`lenet_view`/`render()` for both styles - all warn correctly and don't crash
- [x] Verified `layered_view`'s output is byte-identical to calling `flow_view` directly with equivalent args
- [x] Built docs locally to confirm the `Deprecated:` docstring section renders correctly