### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/docs/source/snippets/install/pypi.txt
+++ b/docs/source/snippets/install/pypi.txt
@@ -1,1 +1,1 @@
-pip install visualtorch==1.2.0
+pip install visualtorch==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="1.2.0",
+    version="1.2.1",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     description="Architecture visualization of Torch models",


### PR DESCRIPTION
## Summary
- Bumps `setup.py` version to `1.2.1` and updates the `pypi.txt` install snippet to match, prepping for the deprecation-shims release (#109).

## Test plan
- [x] `pre-commit run --all-files` passes