### PR TITLE
Ask first-time contributors to claim one issue at a time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,14 @@ We use GitHub issues to track bugs and feature requests. If you want to report a
 
 The [GitHub Discussions](https://github.com/willyfh/visualtorch/discussions/) is enabled in visualtorch to help the community asking questions and/or propose ideas/solutions.
 
+## Picking Up an Issue
+
+Before starting work, please comment on the issue to let others know you're picking it up, so
+effort isn't duplicated. If you're a first-time contributor, we'd appreciate it if you claimed just
+one issue at a time (especially ones labeled `good first issue`) rather than several at once - it
+gives more people a chance to get involved, and you're welcome to grab another once your first PR
+is merged.
+
 ## Development & PRs
 
 ###  Getting Started


### PR DESCRIPTION
## Summary
- Adds a short "Picking Up an Issue" section to `CONTRIBUTING.md` asking contributors to comment before starting work, and asking first-timers to claim just one issue at a time (especially `good first issue`s).
- Motivation: with several new `good first issue`/`help wanted` issues just filed (#112-#115), there's a real risk one contributor claims all of them - which wouldn't actually help grow the number of distinct active contributors, just the activity of one person.

## Test plan
- [x] `pre-commit run --all-files` passes