### PR TITLE
feat: add connector_fill and connector_width to flow_view and lenet_view (#115)

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -609,3 +609,21 @@ def test_layered_view_drops_index_ignore(sequential_model: nn.Sequential) -> Non
     with pytest.warns(DeprecationWarning, match="layered_view"):
         img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), index_ignore=[0])
     assert img is not None
+
+def test_flow_view_connector_fill_and_width_accepted(residual_model: nn.Module) -> None:
+    """connector_fill and connector_width should visually change the rendered output."""
+    img_custom = flow_view(
+        residual_model,
+        input_shape=(1, 8, 16, 16),
+        connector_fill="red",
+        connector_width=3,
+    )
+    img_default = flow_view(residual_model, input_shape=(1, 8, 16, 16))
+    assert img_custom.tobytes() != img_default.tobytes()
+
+
+def test_flow_view_connector_fill_none_uses_box_outline(residual_model: nn.Module) -> None:
+    """connector_fill=None (the default) should produce the same result as not passing it at all."""
+    img_default = flow_view(residual_model, input_shape=(1, 8, 16, 16))
+    img_explicit_none = flow_view(residual_model, input_shape=(1, 8, 16, 16), connector_fill=None)
+    assert img_default.tobytes() == img_explicit_none.tobytes()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -610,6 +610,7 @@ def test_layered_view_drops_index_ignore(sequential_model: nn.Sequential) -> Non
         img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), index_ignore=[0])
     assert img is not None
 
+
 def test_flow_view_connector_fill_and_width_accepted(residual_model: nn.Module) -> None:
     """connector_fill and connector_width should visually change the rendered output."""
     img_custom = flow_view(

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -387,3 +387,21 @@ def test_lenet_view_2d_shape_seq_len_is_discarded() -> None:
     img_bigger_hidden = lenet_view(model_bigger_hidden, input_shape=(1, 5, 8))
 
     assert img_short_seq.tobytes() != img_bigger_hidden.tobytes()
+
+def test_lenet_view_connector_fill_and_width_accepted(residual_model: nn.Module) -> None:
+    """connector_fill and connector_width should visually change the rendered output."""
+    img_custom = lenet_view(
+        residual_model,
+        input_shape=(1, 4, 8, 8),
+        connector_fill="blue",
+        connector_width=3,
+    )
+    img_default = lenet_view(residual_model, input_shape=(1, 4, 8, 8))
+    assert img_custom.tobytes() != img_default.tobytes()
+
+
+def test_lenet_view_connector_fill_none_uses_box_outline(residual_model: nn.Module) -> None:
+    """connector_fill=None (the default) should produce the same result as not passing it at all."""
+    img_default = lenet_view(residual_model, input_shape=(1, 4, 8, 8))
+    img_explicit_none = lenet_view(residual_model, input_shape=(1, 4, 8, 8), connector_fill=None)
+    assert img_default.tobytes() == img_explicit_none.tobytes()

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -388,6 +388,7 @@ def test_lenet_view_2d_shape_seq_len_is_discarded() -> None:
 
     assert img_short_seq.tobytes() != img_bigger_hidden.tobytes()
 
+
 def test_lenet_view_connector_fill_and_width_accepted(residual_model: nn.Module) -> None:
     """connector_fill and connector_width should visually change the rendered output."""
     img_custom = lenet_view(

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -225,7 +225,17 @@ def flow_view(
     _apply_centering(column_layout, top_margin_for_skips, column_layout.diagram_height)
 
     _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
-    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap, connector_fill, connector_width)
+    _draw_skip_connectors(
+        draw,
+        architecture,
+        column_layout,
+        edge_to_level,
+        num_levels,
+        padding,
+        resolved_level_gap,
+        connector_fill,
+        connector_width,
+    )
 
     draw.flush()
 

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -59,6 +59,8 @@ def flow_view(
     show_dimension: bool = False,
     level_gap: int | None = None,
     show_input: bool = True,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
     one_dim_orientation: str | None = None,
 ) -> PIL.Image:
     """Generate a flow-style architecture visualization for a given torch model.
@@ -106,6 +108,9 @@ def flow_view(
             you're overlaying your own custom input illustration instead. Has no effect on a
             multi-input model, where every input is always shown (omitting any of them would
             make it ambiguous which arrow belongs to which named input).
+        connector_fill (str or tuple, optional): Color for skip-connection lines. Can be a string
+            or a tuple (R, G, B, A). If None, inherits the target box's outline color.
+        connector_width (int, optional): Line width in pixels for skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
 
     Returns:
@@ -220,7 +225,7 @@ def flow_view(
     _apply_centering(column_layout, top_margin_for_skips, column_layout.diagram_height)
 
     _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
-    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap)
+    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap, connector_fill, connector_width)
 
     draw.flush()
 
@@ -394,6 +399,8 @@ def _draw_skip_connectors(
     num_levels: int,
     padding: int,
     resolved_level_gap: int,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
 ) -> None:
     """Draw every skip-connection edge, routed above the diagram.
 
@@ -420,14 +427,15 @@ def _draw_skip_connectors(
         detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
         start_de = getattr(start_box, "de", 0)
         end_de = getattr(end_box, "de", 0)
+        resolved_color = connector_fill if connector_fill is not None else end_box.outline
         draw_connector(
             draw,
             start_box.x2 + start_de / 2,
             start_box.y1 - start_de / 2,
             end_box.x1 + end_de / 2,
             end_box.y1 - end_de / 2,
-            color=end_box.outline,
-            width=1,
+            color=resolved_color,
+            width=connector_width,
             detour_y=detour_y,
         )
 

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -218,7 +218,17 @@ def lenet_view(
     _apply_centering(column_layout, top_margin_for_skips + spread_margin / 2)
 
     _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
-    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap, connector_fill, connector_width)
+    _draw_skip_connectors(
+        draw,
+        architecture,
+        column_layout,
+        edge_to_level,
+        num_levels,
+        padding,
+        resolved_level_gap,
+        connector_fill,
+        connector_width,
+    )
 
     draw.flush()
 

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -58,6 +58,8 @@ def lenet_view(
     level_gap: int | None = None,
     show_dimension: bool = True,
     show_input: bool = True,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
     one_dim_orientation: str | None = None,
 ) -> PIL.Image:
     """Generate a LeNet style architecture visualization for a given torch model.
@@ -110,6 +112,9 @@ def lenet_view(
             arrow belongs to which named input). Ignored (input always kept) when the input feeds
             more than one consumer, e.g. a residual shortcut, since dropping it would silently
             discard that edge.
+        connector_fill (str or tuple, optional): Color for skip-connection lines. Can be a string
+            or a tuple (R, G, B, A). If None, inherits the target box's outline color.
+        connector_width (int, optional): Line width in pixels for skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
 
     Returns:
@@ -213,7 +218,7 @@ def lenet_view(
     _apply_centering(column_layout, top_margin_for_skips + spread_margin / 2)
 
     _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
-    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap)
+    _draw_skip_connectors(draw, architecture, column_layout, edge_to_level, num_levels, padding, resolved_level_gap, connector_fill, connector_width)
 
     draw.flush()
 
@@ -384,6 +389,8 @@ def _draw_skip_connectors(
     num_levels: int,
     padding: int,
     resolved_level_gap: int,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
 ) -> None:
     """Draw every skip-connection edge, routed above the diagram.
 
@@ -409,14 +416,15 @@ def _draw_skip_connectors(
         detour_y = padding + (num_levels - 1 - level) * resolved_level_gap
         start_front = start_box.front_offset() if isinstance(start_box, StackedBox) else 0
         end_front = end_box.front_offset() if isinstance(end_box, StackedBox) else 0
+        resolved_color = connector_fill if connector_fill is not None else end_box.outline
         draw_connector(
             draw,
             start_box.x2 + start_front,
             start_box.y1 + start_front,
             end_box.x1 + end_front,
             end_box.y1 + end_front,
-            color=end_box.outline,
-            width=1,
+            color=resolved_color,
+            width=connector_width,
             detour_y=detour_y,
         )
 

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -75,6 +75,8 @@ class FlowStyleOptions:
     legend: bool = False
     show_dimension: bool = False
     show_input: bool = True
+    connector_fill: str | tuple[int, ...] | None = None
+    connector_width: int = 1
     one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
 
 
@@ -96,6 +98,8 @@ class LenetStyleOptions:
     offset_z: int = 10
     show_dimension: bool = True
     show_input: bool = True
+    connector_fill: str | tuple[int, ...] | None = None
+    connector_width: int = 1
     one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
 
 
@@ -162,6 +166,8 @@ def _render_flow(
         show_dimension=options.show_dimension,
         level_gap=common.level_gap,
         show_input=options.show_input,
+        connector_fill=options.connector_fill,
+        connector_width=options.connector_width,
         one_dim_orientation=options.one_dim_orientation,
     )
 
@@ -198,6 +204,8 @@ def _render_lenet(
         level_gap=common.level_gap,
         show_dimension=options.show_dimension,
         show_input=options.show_input,
+        connector_fill=options.connector_fill,
+        connector_width=options.connector_width,
         one_dim_orientation=options.one_dim_orientation,
     )
 


### PR DESCRIPTION
## Summary

Closes #115

`graph_view` already supported `connector_fill` and `connector_width` for
styling skip-connection lines. This PR brings `flow_view` and `lenet_view`
to parity.

## Problem

In both `flow_view` and `lenet_view`, the skip-connection color and width
were hard-coded inside `_draw_skip_connectors()`:

```python
color=end_box.outline,
width=1,
```

There was no way for users to customize these without patching the library.
`graph_view` had already solved this with `connector_fill` / `connector_width`
params — the same just needed to be wired through for the other two styles.

## Changes

- **`render.py`** — Added `connector_fill: str | tuple | None = None` and
  `connector_width: int = 1` to both `FlowStyleOptions` and `LenetStyleOptions`;
  `_render_flow()` and `_render_lenet()` forward them to their respective view functions.
- **`flow.py`** — Added both params to `flow_view()` signature (with docstring),
  threaded through to `_draw_skip_connectors()`; `connector_fill=None` falls back
  to `end_box.outline` preserving existing default behavior.
- **`lenet_style.py`** — Identical change as `flow.py`.
- **`tests/test_flow.py`** — Two new tests: non-default values are accepted without
  error; `connector_fill=None` produces identical output to the default.
- **`tests/test_lenet_style.py`** — Same two tests for `lenet_view`.

## Backward Compatibility

No breaking changes. Both new params are optional with defaults that reproduce
the existing behavior exactly (`connector_fill=None` inherits the box outline
color, `connector_width=1` was the hard-coded value before).

## Usage Example

```python
# flow_view with a bold red skip connector
img = visualtorch.flow_view(model, input_shape=(1, 8, 16, 16), connector_fill="red", connector_width=3)

# lenet_view with a custom color
img = visualtorch.lenet_view(model, input_shape=(1, 4, 8, 8), connector_fill=(0, 120, 255), connector_width=2)

# Also works via the unified render() entry point
img = visualtorch.render(model, input_shape=(1, 8, 16, 16), style="flow", connector_fill="red", connector_width=3)
```