### PR TITLE
Enable Dependabot and pre-commit.ci auto-fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,15 @@ repos:
         args: ["--fix"]
       # Run the formatter
       - id: ruff-format
+
+ci:
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit hooks
+
+    for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` (weekly updates for GitHub Actions versions and pip dependencies) - activates automatically once merged, no separate install needed.
- Adds a `ci:` block to `.pre-commit-config.yaml` enabling pre-commit.ci's `autofix_prs`, so future PRs with auto-fixable formatting issues get a fix commit pushed automatically instead of just failing. Requires installing the pre-commit.ci GitHub App separately.

## Test plan
- [x] `pre-commit run --all-files` passes