### PR TITLE
Add test coverage for the visualtorch.layered module import path

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -616,7 +616,8 @@ def test_layered_module_path_still_importable() -> None:
     from visualtorch.layered import layered_view as layered_view_from_old_path
 
     assert layered_view_from_old_path is layered_view
-    
+
+
 def test_flow_view_connector_fill_and_width_accepted(residual_model: nn.Module) -> None:
     """connector_fill and connector_width should visually change the rendered output."""
     img_custom = flow_view(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -609,3 +609,10 @@ def test_layered_view_drops_index_ignore(sequential_model: nn.Sequential) -> Non
     with pytest.warns(DeprecationWarning, match="layered_view"):
         img = layered_view(sequential_model, input_shape=(1, 3, 224, 224), index_ignore=[0])
     assert img is not None
+
+
+def test_layered_module_path_still_importable() -> None:
+    """The pre-1.0 `visualtorch.layered` module path should still resolve to the same function."""
+    from visualtorch.layered import layered_view as layered_view_from_old_path
+
+    assert layered_view_from_old_path is layered_view


### PR DESCRIPTION
## Summary
- \`visualtorch/layered.py\` (the pre-1.0 backward-compat module path) had 0% test coverage - we tested \`layered_view\` itself, but never the actual \`from visualtorch.layered import layered_view\` import path specifically.
- Adds a small test asserting that import resolves to the same function, as a tripwire against a future refactor silently breaking this compat path again.

## Test plan
- [x] Full test suite passes (139/139)