### PR TITLE
Invite people to share their work

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ VisualTorch has been used in published research, including works published in Na
 
 See the [Research Showcase page](https://visualtorch.readthedocs.io/en/latest/markdown/showcase/index.html) for the full list.
 
+Used VisualTorch in your own research? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to add it to the showcase.
+
 ## Examples
 
 See the [Usage Examples page](https://visualtorch.readthedocs.io/en/latest/usage_examples/index.html).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ VisualTorch has been used in published research, including works published in Na
 
 See the [Research Showcase page](https://visualtorch.readthedocs.io/en/latest/markdown/showcase/index.html) for the full list.
 
-Used VisualTorch in your own research? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to add it to the showcase.
+Used VisualTorch in your research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
 
 ## Examples
 

--- a/docs/source/markdown/showcase/index.md
+++ b/docs/source/markdown/showcase/index.md
@@ -1,7 +1,7 @@
 # Papers Using VisualTorch
 
 Published research that has used VisualTorch to visualize model architectures. Used it in your
-own research? [Open a pull request](https://github.com/willyfh/visualtorch/pulls) to add it here.
+own research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
 
 | Paper                                                                                                                                                                                                                                                                                     | Venue (Year)                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |

--- a/docs/source/markdown/showcase/index.md
+++ b/docs/source/markdown/showcase/index.md
@@ -1,7 +1,6 @@
 # Papers Using VisualTorch
 
-Published research that has used VisualTorch to visualize model architectures. Used it in your
-own research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
+Published research that has used VisualTorch to visualize model architectures. Used it in your own research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
 
 | Paper                                                                                                                                                                                                                                                                                     | Venue (Year)                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |


### PR DESCRIPTION
## Summary
- The existing "Used it in your own research? Open a pull request" invite was buried on the docs Showcase subpage, easy to miss. Adds a short pointer in the README's own "Used in Research" section (which everyone sees) linking to the new pinned Discussion for sharing.

## Test plan
- [x] \`pre-commit run --all-files\` passes