### PR TITLE
Add configurable flow legend position

### DIFF
--- a/docs/examples/flow/plot_legend_position.py
+++ b/docs/examples/flow/plot_legend_position.py
@@ -1,0 +1,61 @@
+"""Legend Position
+=======================================
+
+Place the flow legend above or below the diagram, aligned left, center, or right.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Conv2d(3, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(16, 32, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.AdaptiveAvgPool2d((1, 1)),
+    nn.Flatten(),
+    nn.Linear(64, 10),
+)
+
+input_shape = (1, 3, 64, 64)
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+
+
+def _show(position: str) -> None:
+    img = visualtorch.render(
+        model,
+        input_shape=input_shape,
+        style="flow",
+        legend=True,
+        legend_position=position,
+        spacing=45,
+    )
+    plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+    plt.imshow(img)
+    plt.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+# %%
+# Top-left
+# --------
+
+_show("top-left")
+
+# %%
+# Top-center
+# ----------
+
+_show("top-center")
+
+# %%
+# Bottom-right
+# ------------
+
+_show("bottom-right")

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -210,6 +210,71 @@ def test_flow_view_with_legend(sequential_model: nn.Sequential) -> None:
     assert img is not None
 
 
+@pytest.mark.parametrize(
+    "legend_position",
+    ["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"],
+)
+def test_flow_view_with_legend_position(sequential_model: nn.Sequential, legend_position: str) -> None:
+    """legend_position should accept every documented top/bottom alignment."""
+    img = flow_view(
+        sequential_model,
+        input_shape=(1, 3, 32, 32),
+        legend=True,
+        legend_position=legend_position,
+    )
+
+    assert img is not None
+
+
+def test_flow_view_default_legend_position_matches_bottom_left(sequential_model: nn.Sequential) -> None:
+    """The default legend placement should preserve the previous bottom-left layout."""
+    default = flow_view(sequential_model, input_shape=(1, 3, 32, 32), legend=True)
+    explicit = flow_view(
+        sequential_model,
+        input_shape=(1, 3, 32, 32),
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert default.tobytes() == explicit.tobytes()
+
+
+def test_flow_view_legend_position_moves_legend_vertically(sequential_model: nn.Sequential) -> None:
+    """Top and bottom legend placements should produce different layouts."""
+    top = flow_view(sequential_model, input_shape=(1, 3, 32, 32), legend=True, legend_position="top-left")
+    bottom = flow_view(sequential_model, input_shape=(1, 3, 32, 32), legend=True, legend_position="bottom-left")
+
+    assert top.size == bottom.size
+    assert top.tobytes() != bottom.tobytes()
+
+
+def test_flow_view_legend_position_moves_legend_horizontally(sequential_model: nn.Sequential) -> None:
+    """Left and right legend placements should align the legend within the available width."""
+    left = flow_view(
+        sequential_model,
+        input_shape=(1, 3, 32, 32),
+        legend=True,
+        legend_position="bottom-left",
+        scale_xy=20,
+    )
+    right = flow_view(
+        sequential_model,
+        input_shape=(1, 3, 32, 32),
+        legend=True,
+        legend_position="bottom-right",
+        scale_xy=20,
+    )
+
+    assert left.size == right.size
+    assert left.tobytes() != right.tobytes()
+
+
+def test_flow_view_invalid_legend_position_raises(sequential_model: nn.Sequential) -> None:
+    """Invalid legend positions should fail with a targeted error."""
+    with pytest.raises(ValueError, match="legend_position"):
+        flow_view(sequential_model, input_shape=(1, 3, 32, 32), legend=True, legend_position="left")
+
+
 def test_flow_view_writes_to_file(sequential_model: nn.Sequential, tmp_path: Path) -> None:
     """to_file should save a readable image to disk."""
     out_file = tmp_path / "flow.png"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -103,7 +103,7 @@ def test_render_rejects_kwarg_from_a_different_style(sequential_model: nn.Sequen
 
 
 def test_render_forwards_flow_legend_position(sequential_model: nn.Sequential) -> None:
-    """flow style should accept and forward legend_position through the render entry point."""
+    """Flow style should accept and forward legend_position through the render entry point."""
     top = render(
         sequential_model,
         input_shape=(1, 3, 16, 16),

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -102,6 +102,27 @@ def test_render_rejects_kwarg_from_a_different_style(sequential_model: nn.Sequen
         render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", legend=True)
 
 
+def test_render_forwards_flow_legend_position(sequential_model: nn.Sequential) -> None:
+    """flow style should accept and forward legend_position through the render entry point."""
+    top = render(
+        sequential_model,
+        input_shape=(1, 3, 16, 16),
+        style="flow",
+        legend=True,
+        legend_position="top-left",
+    )
+    bottom = render(
+        sequential_model,
+        input_shape=(1, 3, 16, 16),
+        style="flow",
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert top.size == bottom.size
+    assert top.tobytes() != bottom.tobytes()
+
+
 def test_render_rejects_malformed_mixed_input_shape_with_clear_error(sequential_model: nn.Sequential) -> None:
     """A shape tuple mixing raw ints and nested shape-tuples at the top level is ambiguous and
     should raise a clear ValueError rather than being silently misinterpreted.

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -8,6 +8,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from math import ceil
+from typing import Literal
 
 import aggdraw
 import PIL
@@ -28,7 +29,16 @@ from .utils.utils import (
     linear_layout,
     resolve_palette,
     self_multiply,
-    vertical_image_concat,
+)
+
+LegendPosition = Literal["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"]
+_LEGEND_POSITIONS: tuple[LegendPosition, ...] = (
+    "top-left",
+    "top-right",
+    "top-center",
+    "bottom-left",
+    "bottom-right",
+    "bottom-center",
 )
 
 
@@ -62,6 +72,7 @@ def flow_view(
     connector_fill: str | tuple[int, ...] | None = None,
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
+    legend_position: LegendPosition = "bottom-left",
 ) -> PIL.Image:
     """Generate a flow-style architecture visualization for a given torch model.
 
@@ -112,10 +123,15 @@ def flow_view(
             or a tuple (R, G, B, A). If None, inherits the target box's outline color.
         connector_width (int, optional): Line width in pixels for skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
+        legend_position (str, optional): Where to place the legend when `legend=True`. One of
+            `"top-left"`, `"top-right"`, `"top-center"`, `"bottom-left"`, `"bottom-right"`, or
+            `"bottom-center"`. Defaults to `"bottom-left"`, matching the previous layout.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
     """
+    _validate_legend_position(legend_position)
+
     if one_dim_orientation is not None:
         warnings.warn(
             "`one_dim_orientation` is deprecated and will be removed in a future release, "
@@ -259,12 +275,20 @@ def flow_view(
             spacing,
             padding,
             background_fill,
+            legend_position,
         )
 
     if to_file is not None:
         img.save(to_file)
 
     return img
+
+
+def _validate_legend_position(legend_position: str) -> None:
+    if legend_position not in _LEGEND_POSITIONS:
+        supported = ", ".join(f"{position!r}" for position in _LEGEND_POSITIONS)
+        error_msg = f"unsupported legend_position: {legend_position!r}. Supported positions: {supported}."
+        raise ValueError(error_msg)
 
 
 def _box_factory(
@@ -462,8 +486,9 @@ def _draw_legend(
     spacing: int,
     padding: int,
     background_fill: str | tuple[int, ...],
+    legend_position: LegendPosition,
 ) -> PIL.Image:
-    """Build and append a color legend, one entry per layer type, below the diagram."""
+    """Build and place a color legend, one entry per layer type."""
     text_height = font.getbbox("Ag")[3]
     cube_size = text_height
 
@@ -512,7 +537,40 @@ def _draw_legend(
         background_fill=background_fill,
         horizontal=True,
     )
-    return vertical_image_concat(img, legend_image, background_fill=background_fill)
+    return _place_legend(img, legend_image, legend_position, background_fill)
+
+
+def _place_legend(
+    img: PIL.Image,
+    legend_image: PIL.Image,
+    legend_position: LegendPosition,
+    background_fill: str | tuple[int, ...],
+) -> PIL.Image:
+    """Place the legend outside the diagram while aligning it within the final canvas."""
+    vertical_position, horizontal_position = legend_position.split("-", 1)
+    canvas = Image.new(
+        "RGBA",
+        (max(img.width, legend_image.width), img.height + legend_image.height),
+        background_fill,
+    )
+    legend_x = _horizontal_legend_offset(canvas.width, legend_image.width, horizontal_position)
+
+    if vertical_position == "top":
+        canvas.paste(legend_image, (legend_x, 0))
+        canvas.paste(img, (0, legend_image.height))
+    else:
+        canvas.paste(img, (0, 0))
+        canvas.paste(legend_image, (legend_x, img.height))
+    return canvas
+
+
+def _horizontal_legend_offset(canvas_width: int, legend_width: int, horizontal_position: str) -> int:
+    """Return the x offset for the legend row inside the final canvas."""
+    if horizontal_position == "right":
+        return canvas_width - legend_width
+    if horizontal_position == "center":
+        return (canvas_width - legend_width) // 2
+    return 0
 
 
 def _column_label_and_center(column: list[VolumetricBox]) -> tuple[str, float]:

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -18,7 +18,7 @@ from typing import Any, Literal
 from PIL import Image
 from torch import nn
 
-from .flow import flow_view
+from .flow import LegendPosition, flow_view
 from .graph import graph_view
 from .lenet_style import lenet_view
 from .utils.utils import InputShape
@@ -74,6 +74,7 @@ class FlowStyleOptions:
     draw_funnel: bool = True
     shade_step: int = 10
     legend: bool = False
+    legend_position: LegendPosition = "bottom-left"
     show_dimension: bool = False
     show_input: bool = True
     connector_fill: str | tuple[int, ...] | None = None
@@ -162,6 +163,7 @@ def _render_flow(
         draw_funnel=options.draw_funnel,
         shade_step=options.shade_step,
         legend=options.legend,
+        legend_position=options.legend_position,
         font=common.font,
         font_color=common.font_color,
         opacity=common.opacity,


### PR DESCRIPTION
Fixes #114

This adds a `legend_position` option to `flow_view`, so the existing flow legend does not have to stay fixed below the diagram.

Supported positions are:

- `top-left`
- `top-center`
- `top-right`
- `bottom-left`
- `bottom-center`
- `bottom-right`

The default is still `bottom-left`, so existing `legend=True` output keeps the same layout as before.

I also wired the option through `visualtorch.render(..., style='flow')`.

I left `graph_view` and `lenet_view` alone because they do not expose `legend` on the current target branch yet. Once #113 lands, the same option can be added there too.

## Smoke check

I checked these locally with a small flow diagram.

Top-left:

![flow legend top-left](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-133-smoke-images/flow_legend_top-left.png)

Top-center:

![flow legend top-center](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-133-smoke-images/flow_legend_top-center.png)

Bottom-right:

![flow legend bottom-right](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-133-smoke-images/flow_legend_bottom-right.png)

All six supported positions:

![flow legend positions summary](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-133-smoke-images/flow_legend_positions_summary.png)

These screenshots are only attached for review; they are not part of this PR diff.

## Tests

```text
pytest tests/test_flow.py tests/test_render.py
```

```text
77 passed
```

Also checked:

- default `legend=True` matches `legend_position='bottom-left'`
- invalid `legend_position='left'` raises `ValueError`
- `render(..., style='flow', legend_position='top-left')` works
