### PR TITLE
Invite third-party contributions to the Research Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ VisualTorch has been used in published research, including works published in Na
 
 See the [Research Showcase page](https://visualtorch.readthedocs.io/en/latest/markdown/showcase/index.html) for the full list.
 
-Used VisualTorch in your research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
+Used VisualTorch in your research, built something with it, or found a paper that cites it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) or [open a pull request](https://github.com/willyfh/visualtorch/pulls) to add it directly - we'd love to hear.
 
 ## Examples
 

--- a/docs/source/markdown/showcase/index.md
+++ b/docs/source/markdown/showcase/index.md
@@ -1,6 +1,6 @@
 # Papers Using VisualTorch
 
-Published research that has used VisualTorch to visualize model architectures. Used it in your own research or built something with it? [Tell us about it](https://github.com/willyfh/visualtorch/discussions) - we'd love to hear.
+Published research that has used VisualTorch to visualize model architectures. Used it in your own research, or know of a paper that cites it - even if it's not yours? [Open a pull request](https://github.com/willyfh/visualtorch/pulls) to add it here, or [tell us about it](https://github.com/willyfh/visualtorch/discussions) and we'll add it for you.
 
 | Paper                                                                                                                                                                                                                                                                                     | Venue (Year)                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |


### PR DESCRIPTION
## Summary
- Broadens the research-invite wording in the README and the showcase page so anyone who finds a paper citing VisualTorch can open a PR to add it, not just the paper's own authors self-reporting.

## Test plan
- [x] `pre-commit run --files README.md docs/source/markdown/showcase/index.md` passes