### PR TITLE
Support integer/bool input_dtype for models starting with nn.Embedding

### DIFF
--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -158,3 +158,54 @@ def test_show_dimension_includes_every_output_shape(lstm_using_hidden_state_mode
     """show_dimension=True shouldn't crash, and should still work, for a multi-output leaf module."""
     img = view(lstm_using_hidden_state_model, input_shape=(1, 7, 10), show_dimension=True)  # type: ignore[operator]
     assert img is not None
+
+
+@pytest.fixture()
+def embedding_model() -> nn.Module:
+    """A model starting with nn.Embedding - requires an integer/long index tensor.
+
+    The tracer's dummy input was always a uniformly random float tensor, which nn.Embedding (and
+    any other integer/bool-input layer) rejects outright, crashing before any tracing could
+    happen at all.
+    """
+
+    class TokenModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(1000, 32)
+            self.fc = nn.Linear(32, 10)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.embed(x))
+
+    return TokenModel()
+
+
+def test_extract_architecture_rejects_embedding_model_without_integer_input_dtype(embedding_model: nn.Module) -> None:
+    """Without input_dtype, the dummy tensor is float - nn.Embedding rejects it outright.
+
+    Pinning this failure down explicitly (rather than just testing the fix in isolation) makes
+    sure the fix is actually doing something: if this ever stopped raising, the `input_dtype`
+    tests below would no longer be verifying a real fix.
+    """
+    with pytest.raises(RuntimeError, match="scalar type"):
+        extract_architecture(embedding_model, (1, 16))
+
+
+def test_extract_architecture_supports_embedding_model_via_integer_input_dtype(embedding_model: nn.Module) -> None:
+    """input_dtype=torch.long should let the tracer build a valid dummy index tensor, and the
+    Embedding layer should be traced like any other layer, with its real output shape recorded.
+    """  # noqa: D205
+    architecture = extract_architecture(embedding_model, (1, 16), input_dtype=torch.long)
+    embedding_layer = next(
+        layer for column in architecture.columns for layer in column if isinstance(layer.module, nn.Embedding)
+    )
+
+    assert embedding_layer.output_shape == (1, 16, 32)
+
+
+@pytest.mark.parametrize("view", [graph_view, flow_view, lenet_view])
+def test_view_renders_embedding_model_with_integer_input_dtype(embedding_model: nn.Module, view: object) -> None:
+    """Every style should render a token-embedding model end to end once given input_dtype."""
+    img = view(embedding_model, input_shape=(1, 16), input_dtype=torch.long)  # type: ignore[operator]
+    assert img is not None

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -154,6 +154,73 @@ def test_render_handles_unused_input_tensor() -> None:
     assert img is not None
 
 
+@pytest.mark.parametrize("style", ["graph", "flow", "lenet"])
+def test_render_supports_integer_input_dtype_for_embedding_model(style: str) -> None:
+    """A model starting with nn.Embedding needs an integer dummy tensor, not the default float
+    one - input_dtype=torch.long should make every style render it successfully.
+    """  # noqa: D205
+
+    class TokenModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(1000, 16)
+            self.fc = nn.Linear(16, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(self.embed(x))
+
+    img = render(TokenModel(), input_shape=(1, 8), style=style, input_dtype=torch.long)
+    assert img is not None
+
+
+def test_render_multi_input_supports_per_tensor_input_dtype() -> None:
+    """A multi-input model mixing a token (long) branch and a continuous (float) branch should
+    render once each input tensor gets its own dtype via a per-position tuple.
+    """  # noqa: D205
+
+    class TokenAndFeatureModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(1000, 8)
+            self.fc_tokens = nn.Linear(8, 8)
+            self.fc_features = nn.Linear(10, 8)
+            self.head = nn.Linear(16, 4)
+
+        def forward(self, tokens: torch.Tensor, features: torch.Tensor) -> torch.Tensor:
+            token_repr = self.fc_tokens(self.embed(tokens)).mean(dim=1)
+            feature_repr = self.fc_features(features)
+            return self.head(torch.cat([token_repr, feature_repr], dim=-1))
+
+    img = render(
+        TokenAndFeatureModel(),
+        input_shape=((1, 8), (1, 10)),
+        style="graph",
+        input_dtype=(torch.long, None),
+    )
+    assert img is not None
+
+
+def test_render_rejects_invalid_input_dtype(sequential_model: nn.Sequential) -> None:
+    """A non-dtype value for input_dtype should raise a clear ValueError, not an obscure one
+    from deep inside torch.rand/torch.zeros.
+    """  # noqa: D205
+    with pytest.raises(ValueError, match="input_dtype must be"):
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", input_dtype="not-a-dtype")
+
+
+def test_render_rejects_input_dtype_tuple_arity_mismatch(siamese_model: nn.Module) -> None:
+    """A per-position input_dtype tuple with the wrong length for a multi-input model should
+    raise a clear ValueError.
+    """  # noqa: D205
+    with pytest.raises(ValueError, match="input_dtype must be"):
+        render(
+            siamese_model,
+            input_shape=((1, 3, 16, 16), (1, 10)),
+            style="graph",
+            input_dtype=(torch.float32,),
+        )
+
+
 @pytest.mark.parametrize("palette", sorted(PALETTES))
 def test_render_runs_for_every_named_palette(sequential_model: nn.Sequential, palette: str) -> None:
     """Every named palette should render without error - catches any malformed hex color."""

--- a/visualtorch/backend.py
+++ b/visualtorch/backend.py
@@ -18,7 +18,7 @@ from torch import nn
 from .utils.layer_utils import Input
 from .utils.recorder import trace_module_graph
 from .utils.traced_layer import TracedLayer
-from .utils.utils import InputShape, validate_input_shape
+from .utils.utils import InputDtype, InputShape, validate_input_dtype, validate_input_shape
 
 _INPUT_NODE_ID = "__input_dummy__"
 
@@ -48,7 +48,11 @@ class Architecture:
             yield self._index_to_id[int(start_idx)], self._index_to_id[int(end_idx)]
 
 
-def extract_architecture(model: nn.Module, input_shape: InputShape) -> Architecture:
+def extract_architecture(
+    model: nn.Module,
+    input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
+) -> Architecture:
     """Trace a model's forward pass and extract its structure as an `Architecture`.
 
     Traces an actual forward pass (see `visualtorch.utils.recorder.trace_module_graph`) instead of
@@ -61,15 +65,23 @@ def extract_architecture(model: nn.Module, input_shape: InputShape) -> Architect
             dim (e.g. (1, 3, 224, 224)). For a model whose forward() takes multiple separate input
             tensors, pass a tuple of per-tensor shapes instead, one per positional argument in
             order, e.g. ((1, 3, 224, 224), (1, 10)).
+        input_dtype (torch.dtype, optional): The dtype of the dummy input tensor(s) used to trace
+            the model. Defaults to `None` for every input, giving a uniformly random float
+            tensor - the long-standing behavior. Needed for a model that starts with an
+            integer/bool-input layer (e.g. `nn.Embedding`, which rejects a float index tensor):
+            pass `torch.long`, or - for a model with multiple input tensors of different kinds - a
+            tuple of per-tensor dtypes, e.g. `(torch.long, None)`.
 
     Returns:
         Architecture: The traced model's structure.
     """
     input_shapes = validate_input_shape(input_shape)
+    input_dtypes = validate_input_dtype(input_dtype, len(input_shapes))
 
     id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids = trace_module_graph(
         model,
         input_shapes,
+        input_dtypes,
     )
 
     nodes = list(id_to_module.keys())

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -22,6 +22,7 @@ from .utils.utils import (
     Box,
     ColorWheel,
     ImageDraw,
+    InputDtype,
     InputShape,
     format_shape_label,
     get_rgba_tuple,
@@ -35,6 +36,7 @@ from .utils.utils import (
 def flow_view(
     model: nn.Module | nn.Sequential | nn.ModuleList,
     input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
     to_file: str | None = None,
     min_z: int = 10,
     min_xy: int = 10,
@@ -71,6 +73,12 @@ def flow_view(
             model whose forward() takes multiple separate input tensors, pass a tuple of
             per-tensor shapes instead, one per positional argument in order, e.g.
             ((1, 3, 224, 224), (1, 10)).
+        input_dtype (torch.dtype, optional): The dtype of the dummy input tensor(s) used to trace
+            the model. Defaults to `None` for every input, giving a uniformly random float
+            tensor. Needed for a model that starts with an integer/bool-input layer (e.g.
+            `nn.Embedding`, which rejects a float index tensor): pass `torch.long`, or - for a
+            model with multiple input tensors of different kinds - a tuple of per-tensor dtypes,
+            e.g. `(torch.long, None)`.
         to_file (str, optional): Path to the file to write the created image. Overwrite if exist.
             Image type is inferred from the file extension. Providing None will disable writing.
         min_z (int, optional): Minimum size in pixels that a layer will have along the z-axis.
@@ -132,7 +140,7 @@ def flow_view(
     if color_map is not None:
         _color_map = defaultdict(dict, color_map)
 
-    architecture = extract_architecture(model, input_shape)
+    architecture = extract_architecture(model, input_shape, input_dtype)
 
     # The synthetic input column has no counterpart in this style (flow_view never drew an
     # "Input" box even before the v2 backend unification), so a single input is dropped by

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -15,12 +15,23 @@ from PIL import Image, ImageFont
 from .backend import extract_architecture
 from .connectors import compute_skip_levels, draw_connector
 from .utils.traced_layer import TracedLayer
-from .utils.utils import Box, Circle, ColorWheel, Ellipses, ImageDraw, InputShape, format_shape_label, resolve_palette
+from .utils.utils import (
+    Box,
+    Circle,
+    ColorWheel,
+    Ellipses,
+    ImageDraw,
+    InputDtype,
+    InputShape,
+    format_shape_label,
+    resolve_palette,
+)
 
 
 def graph_view(
     model: torch.nn.Module,
     input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
     to_file: str | None = None,
     color_map: dict[Any, Any] | None = None,
     palette: str = "okabe_ito",
@@ -48,6 +59,12 @@ def graph_view(
         input_shape (tuple): The shape of the input tensor. For a model whose forward() takes
             multiple separate input tensors, pass a tuple of per-tensor shapes instead, one per
             positional argument in order, e.g. ((1, 3, 224, 224), (1, 10)).
+        input_dtype (torch.dtype, optional): The dtype of the dummy input tensor(s) used to trace
+            the model. Defaults to `None` for every input, giving a uniformly random float
+            tensor. Needed for a model that starts with an integer/bool-input layer (e.g.
+            `nn.Embedding`, which rejects a float index tensor): pass `torch.long`, or - for a
+            model with multiple input tensors of different kinds - a tuple of per-tensor dtypes,
+            e.g. `(torch.long, None)`.
         to_file (str, optional): Path to the file to write the created image to. If the image does not exist yet,
             it will be created, else overwritten. Image type is inferred from the file ending. Providing None
             will disable writing.
@@ -93,7 +110,7 @@ def graph_view(
     if color_map is not None:
         _color_map = defaultdict(dict, color_map)
 
-    architecture = extract_architecture(model, input_shape)
+    architecture = extract_architecture(model, input_shape, input_dtype)
 
     # Hiding is only honored when it's safe to: an input feeding more than one consumer (e.g. a
     # residual block's raw-input shortcut) must stay visible regardless of show_input, since

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -21,6 +21,7 @@ from .utils.traced_layer import TracedLayer
 from .utils.utils import (
     ColorWheel,
     ImageDraw,
+    InputDtype,
     InputShape,
     StackedBox,
     format_shape_label,
@@ -35,6 +36,7 @@ _LABEL_ROW_HEIGHT = 100
 def lenet_view(
     model: nn.Module | nn.Sequential | nn.ModuleList,
     input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
     to_file: str | None = None,
     min_z: int = 1,
     min_xy: int = 10,
@@ -72,6 +74,12 @@ def lenet_view(
             model whose forward() takes multiple separate input tensors, pass a tuple of
             per-tensor shapes instead, one per positional argument in order, e.g.
             ((1, 3, 224, 224), (1, 10)).
+        input_dtype (torch.dtype, optional): The dtype of the dummy input tensor(s) used to trace
+            the model. Defaults to `None` for every input, giving a uniformly random float
+            tensor. Needed for a model that starts with an integer/bool-input layer (e.g.
+            `nn.Embedding`, which rejects a float index tensor): pass `torch.long`, or - for a
+            model with multiple input tensors of different kinds - a tuple of per-tensor dtypes,
+            e.g. `(torch.long, None)`.
         to_file (str, optional): Path to the file to write the created image. Overwrite if exist.
             Image type is inferred from the file extension. Providing None will disable writing.
         min_z (int, optional): Minimum size in pixels that a layer will have along the z-axis.
@@ -136,7 +144,7 @@ def lenet_view(
     if color_map is not None:
         _color_map = defaultdict(dict, color_map)
 
-    architecture = extract_architecture(model, input_shape)
+    architecture = extract_architecture(model, input_shape, input_dtype)
 
     # Hiding is only honored when it's safe to: an input feeding more than one consumer (e.g. a
     # residual block's raw-input shortcut) must stay visible regardless of show_input, since

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -21,7 +21,7 @@ from torch import nn
 from .flow import flow_view
 from .graph import graph_view
 from .lenet_style import lenet_view
-from .utils.utils import InputShape
+from .utils.utils import InputDtype, InputShape
 
 Style = Literal["graph", "flow", "lenet"]
 
@@ -30,6 +30,7 @@ Style = Literal["graph", "flow", "lenet"]
 class CommonOptions:
     """Options accepted by every rendering style."""
 
+    input_dtype: InputDtype | None = None
     to_file: str | None = None
     color_map: dict[Any, Any] | None = None
     palette: str = "okabe_ito"
@@ -113,6 +114,7 @@ def _render_graph(
     return graph_view(
         model,
         input_shape,
+        input_dtype=common.input_dtype,
         to_file=common.to_file,
         color_map=common.color_map,
         palette=common.palette,
@@ -144,6 +146,7 @@ def _render_flow(
     return flow_view(
         model,
         input_shape,
+        input_dtype=common.input_dtype,
         to_file=common.to_file,
         min_z=options.min_z,
         min_xy=options.min_xy,
@@ -183,6 +186,7 @@ def _render_lenet(
     return lenet_view(
         model,
         input_shape,
+        input_dtype=common.input_dtype,
         to_file=common.to_file,
         min_z=options.min_z,
         min_xy=options.min_xy,

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -209,6 +209,7 @@ class Recorder:
 def trace_module_graph(
     model: nn.Module,
     input_shapes: tuple[tuple[int, ...], ...],
+    input_dtypes: tuple[torch.dtype | None, ...] | None = None,
 ) -> tuple[
     dict[str, nn.Module],
     dict[str, tuple[int, ...]],
@@ -223,6 +224,13 @@ def trace_module_graph(
         input_shapes (tuple): One shape tuple per input tensor (including batch dim each), in the
             order forward() expects them positionally. A single-input model still passes a
             length-1 tuple, e.g. `((1, 3, 224, 224),)`.
+        input_dtypes (tuple, optional): One dtype (or `None`) per input tensor, same order as
+            `input_shapes`. `None` (the default, for every input) keeps the long-standing
+            behavior of a uniformly random float dummy tensor. An integer/bool dtype (e.g.
+            `torch.long`, needed by `nn.Embedding`-style lookups, which reject a float index
+            tensor) instead gets an all-zero dummy - index `0` is always a valid row regardless
+            of the real embedding table's size, and tracing only needs correct shapes to
+            propagate, not realistic values.
 
     Returns:
         tuple: A tuple containing:
@@ -237,9 +245,13 @@ def trace_module_graph(
             - input_ids (list): One synthetic node id per input tensor, in the same order as
                 `input_shapes`.
     """
+    dtypes = input_dtypes if input_dtypes is not None else (None,) * len(input_shapes)
     dummy_inputs = []
-    for i, shape in enumerate(input_shapes):
-        dummy = torch.rand(shape).as_subclass(RecorderTensor)
+    for i, (shape, dtype) in enumerate(zip(input_shapes, dtypes, strict=True)):
+        if dtype is not None and not dtype.is_floating_point:
+            dummy = torch.zeros(shape, dtype=dtype).as_subclass(RecorderTensor)
+        else:
+            dummy = torch.rand(shape, dtype=dtype).as_subclass(RecorderTensor)
         dummy._producer_ids = {f"{INPUT_NODE_ID}#{i}"}  # noqa: SLF001
         dummy_inputs.append(dummy)
 

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -4,14 +4,19 @@
 # Copyright (C) 2024 Willy Fitra Hendria
 # SPDX-License-Identifier: MIT
 
-from typing import Any
+from typing import Any, TypeAlias
 
 import aggdraw
 import PIL
+import torch
 from PIL import Image, ImageColor, ImageDraw
 
 InputShape = tuple[int, ...] | tuple[tuple[int, ...], ...]
 """A single flat shape (one input tensor) or a tuple of per-tensor shapes (multiple inputs)."""
+
+InputDtype: TypeAlias = torch.dtype | tuple[torch.dtype | None, ...]
+"""A single dtype (applied to every input tensor) or a tuple of per-tensor dtypes (`None` for any
+entry keeps that tensor's default float dummy)."""
 
 
 class Shape:
@@ -412,6 +417,45 @@ def validate_input_shape(input_shape: tuple) -> tuple[tuple[int, ...], ...]:
         raise ValueError(error_msg)
 
     return tuple(input_shape)
+
+
+def validate_input_dtype(input_dtype: InputDtype | None, n_inputs: int) -> tuple[torch.dtype | None, ...]:
+    """Validate input_dtype and normalize it to one dtype (or None) per input tensor.
+
+    Accepts `None` (every input gets its default dummy - a float tensor via `torch.rand`, the
+    long-standing behavior), a single `torch.dtype` (applied to every input tensor), or a tuple of
+    length `n_inputs` mixing per-tensor `torch.dtype`s and/or `None`s (`None` for a given position
+    keeps that tensor's default float dummy) - for a model whose forward() takes multiple separate
+    input tensors of different kinds, e.g. token ids alongside a continuous feature vector.
+
+    Args:
+        input_dtype: The dtype(s) to validate, or `None`.
+        n_inputs (int): How many input tensors the model's forward() takes.
+
+    Returns:
+        tuple: A tuple of length `n_inputs`, each entry either a `torch.dtype` or `None`.
+
+    Raises:
+        ValueError: If input_dtype is neither `None`, a single `torch.dtype`, nor a tuple of
+            `n_inputs` entries each a `torch.dtype` or `None`.
+    """
+    if input_dtype is None:
+        return (None,) * n_inputs
+
+    if isinstance(input_dtype, torch.dtype):
+        return (input_dtype,) * n_inputs
+
+    error_msg = (
+        "input_dtype must be either a single torch.dtype, e.g. torch.long, or - for models whose "
+        f"forward() takes multiple separate input tensors - a tuple of {n_inputs} per-tensor "
+        f"dtypes (each a torch.dtype or None). Got {input_dtype!r} instead."
+    )
+    if not isinstance(input_dtype, tuple) or len(input_dtype) != n_inputs:
+        raise ValueError(error_msg)
+    if not all(dtype is None or isinstance(dtype, torch.dtype) for dtype in input_dtype):
+        raise ValueError(error_msg)
+
+    return input_dtype
 
 
 def self_multiply(tensor_tuple: tuple | list) -> int | float:


### PR DESCRIPTION
## Summary
- The tracer's dummy input was always a uniformly random float tensor (`torch.rand`), which any integer/bool-input layer (most commonly `nn.Embedding`, used by essentially every token-based NLP/Transformer model) rejects outright - crashing before tracing could even begin.
- Adds an optional `input_dtype` param through `render()`/`graph_view()`/`flow_view()`/`lenet_view()`/`extract_architecture()`, accepting a single `torch.dtype` or a per-input tuple (for multi-input models mixing e.g. token ids and continuous features).
- Defaults to `None` everywhere, reproducing the existing float-only behavior exactly - purely additive.
- For an integer/bool dtype, the dummy tensor is built via `torch.zeros(shape, dtype=dtype)` rather than `torch.rand` - index `0` is always a valid row regardless of the real embedding table's size, and tracing only needs correct shapes to propagate, not realistic values. Float dtypes keep using `torch.rand`, unchanged, to preserve the existing "generic representative value" tracing behavior other models already depend on.

## Test plan
- [x] `tests/test_regression_issues.py`: pins down the original crash explicitly, then confirms the fix at the `extract_architecture` level and across all three view functions
- [x] `tests/test_render.py`: `render()` support across all 3 styles, mixed-dtype multi-input case, and validation-error tests (bad dtype value, wrong tuple length)
- [x] Full suite: 156/156 passing
- [x] `pre-commit run --all-files` clean, twice in a row