### PR TITLE
docs(examples): add show_neurons=False example for graph_view

### DIFF
--- a/docs/examples/graph/plot_hide_neurons_graph.py
+++ b/docs/examples/graph/plot_hide_neurons_graph.py
@@ -1,0 +1,50 @@
+"""Hide Neurons
+=======================================
+
+By default ``graph_view`` draws one node per neuron (constrained by ``max_neurons``), which is
+great for seeing the width of each layer but gets busy for anything beyond a toy model. Setting
+``show_neurons=False`` collapses each layer down to a single node, giving a much more compact,
+block-diagram-like view that stays readable for deeper networks.
+
+The two renders below use the *same* model so the difference is easy to spot.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Linear(4, 8),
+    nn.ReLU(),
+    nn.Linear(8, 6),
+    nn.ReLU(),
+    nn.Linear(6, 3),
+)
+
+input_shape = (1, 4)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+
+
+def _show(*, show_neurons: bool) -> None:
+    img = visualtorch.render(model, input_shape, style="graph", show_neurons=show_neurons)
+    plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+    plt.imshow(img)
+    plt.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+# %%
+# ``show_neurons=True`` (default)
+# -------------------------------
+# One node per neuron - the width of every layer is visible at a glance.
+
+_show(show_neurons=True)
+
+# %%
+# ``show_neurons=False``
+# ----------------------
+# One node per layer - a compact view that scales to deeper models without the clutter.
+
+_show(show_neurons=False)

--- a/docs/examples/graph/plot_hide_neurons_graph.py
+++ b/docs/examples/graph/plot_hide_neurons_graph.py
@@ -1,7 +1,7 @@
 """Hide Neurons
 =======================================
 
-By default ``graph_view`` draws one node per neuron (constrained by ``max_neurons``), which is
+By default ``graph_view`` draws one node per neuron (constrained by ``ellipsize_after``), which is
 great for seeing the width of each layer but gets busy for anything beyond a toy model. Setting
 ``show_neurons=False`` collapses each layer down to a single node, giving a much more compact,
 block-diagram-like view that stays readable for deeper networks.


### PR DESCRIPTION
Closes #140.

Adds `docs/examples/graph/plot_hide_neurons_graph.py`, following the existing `plot_*.py` Sphinx-Gallery pattern.

**What it shows**
Renders the *same* small dense model twice so the effect of `show_neurons` is obvious:

- `show_neurons=True` (default) — one node per neuron
- `show_neurons=False` — one node per layer (compact, scales to deeper models)

**Verification**
- Ran the file top-to-bottom locally (CPU torch); both cells render — `True` → 1570×490 px, `False` → 1570×170 px, so the collapse is clearly visible.
- `ruff check` passes with the repo's own config (`line-length=120`, D205 handled via the `# noqa` header like sibling examples).

Happy to tweak the model or wording if you'd prefer a different demo network.