### PR TITLE
Add custom font examples for all styles

### DIFF
--- a/docs/examples/flow/plot_custom_font.py
+++ b/docs/examples/flow/plot_custom_font.py
@@ -1,0 +1,45 @@
+"""Custom Font
+=======================================
+
+Use ``font`` and ``font_color`` to style the dimension labels in a flow view. This example uses
+Matplotlib's bundled bold italic STIX font, avoiding a platform-specific font path.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from matplotlib import font_manager
+from PIL import ImageFont
+from torch import nn
+
+# Fall back to Pillow's default font if the requested TrueType font is unavailable.
+font_properties = font_manager.FontProperties(family="STIXGeneral", style="italic", weight="bold")
+try:
+    font_path = font_manager.findfont(font_properties, fallback_to_default=False)
+    custom_font = ImageFont.truetype(font_path, 20)
+except (OSError, ValueError):
+    custom_font = ImageFont.load_default()
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+
+input_shape = (1, 3, 64, 64)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="flow",
+    show_dimension=True,
+    font=custom_font,
+    font_color="#8B1E3F",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/graph/plot_custom_font_graph.py
+++ b/docs/examples/graph/plot_custom_font_graph.py
@@ -1,0 +1,47 @@
+"""Custom Font
+=======================================
+
+Use ``font`` and ``font_color`` to style the dimension labels in a graph view. This example uses
+Matplotlib's bundled bold monospace font, avoiding a platform-specific font path.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from matplotlib import font_manager
+from PIL import ImageFont
+from torch import nn
+
+# Fall back to Pillow's default font if the requested TrueType font is unavailable.
+font_properties = font_manager.FontProperties(family="DejaVu Sans Mono", weight="bold")
+try:
+    font_path = font_manager.findfont(font_properties, fallback_to_default=False)
+    custom_font = ImageFont.truetype(font_path, 16)
+except (OSError, ValueError):
+    custom_font = ImageFont.load_default()
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+
+input_shape = (1, 3, 64, 64)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="graph",
+    layer_spacing=120,
+    show_neurons=False,
+    show_dimension=True,
+    font=custom_font,
+    font_color="#1F4E79",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_custom_font_lenet_style.py
+++ b/docs/examples/lenet_style/plot_custom_font_lenet_style.py
@@ -1,0 +1,47 @@
+"""Custom Font
+=======================================
+
+Use ``font`` and ``font_color`` to style the dimension labels in a LeNet-style view. This example
+uses Matplotlib's bundled Computer Modern sans-serif font, avoiding a platform-specific font path.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from matplotlib import font_manager
+from PIL import ImageFont
+from torch import nn
+
+# Fall back to Pillow's default font if the requested TrueType font is unavailable.
+font_properties = font_manager.FontProperties(family="cmss10")
+try:
+    font_path = font_manager.findfont(font_properties, fallback_to_default=False)
+    custom_font = ImageFont.truetype(font_path, 16)
+except (OSError, ValueError):
+    custom_font = ImageFont.load_default()
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+
+input_shape = (1, 3, 64, 64)
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+    padding=80,
+    spacing=40,
+    show_dimension=True,
+    font=custom_font,
+    font_color="#245C45",
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
Closes #138

This adds a custom-font example for each rendering style:

- Graph uses DejaVu Sans Mono Bold.
- Flow uses STIXGeneral Bold Italic.
- LeNet uses Computer Modern Sans.

Each example loads a TrueType font bundled with Matplotlib and falls back to Pillow's default font if it cannot be loaded. They use `show_dimension=True` so the custom font and color are visible on actual dimension labels.

## Preview

### Graph

![Graph custom font preview](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-138-preview-images/custom_font_graph.png)

### Flow

![Flow custom font preview](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-138-preview-images/custom_font_flow.png)

### LeNet

![LeNet custom font preview](https://github.com/Tsubashimo-Nanato/visualtorch/releases/download/pr-138-preview-images/custom_font_lenet.png)

## Checks

I ran all three example scripts locally.

```text
docs/examples/graph/plot_custom_font_graph.py
docs/examples/flow/plot_custom_font.py
docs/examples/lenet_style/plot_custom_font_lenet_style.py
```

Ruff check, Ruff format check, and `git diff --check` passed.
