### PR TITLE
docs: add dedicated examples for connector_fill and connector_width

### DIFF
--- a/docs/examples/flow/plot_connector_style_flow.py
+++ b/docs/examples/flow/plot_connector_style_flow.py
@@ -54,7 +54,7 @@ img = visualtorch.render(
     color_map=color_map,
     legend=True,
     connector_fill="red",
-    connector_width=3
+    connector_width=3,
 )
 
 dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)

--- a/docs/examples/flow/plot_connector_style_flow.py
+++ b/docs/examples/flow/plot_connector_style_flow.py
@@ -1,0 +1,65 @@
+"""Connector Styling
+=======================================
+
+By default, connectors (the lines drawn between layers) are 1 pixel wide and black.
+You can customize their appearance using ``connector_fill`` and ``connector_width``.
+This is particularly useful when highlighting the flow of data through a complex
+network, or when dealing with skip connections in a residual model.
+
+Here, we render a residual block with a bold red connector of width 3 to make the
+data paths stand out.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A classic ResNet-style block with a plain identity shortcut."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass, with a skip connection around conv1/bn1/relu/conv2/bn2."""
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return self.relu(out)
+
+
+model = ResidualBlock(channels=8)
+
+input_shape = (1, 8, 16, 16)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.BatchNorm2d]["fill"] = "#009E73"
+color_map[nn.ReLU]["fill"] = "#56B4E9"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="flow",
+    color_map=color_map,
+    legend=True,
+    connector_fill="red",
+    connector_width=3
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/graph/plot_connector_style_graph.py
+++ b/docs/examples/graph/plot_connector_style_graph.py
@@ -1,0 +1,66 @@
+"""Connector Styling
+=======================================
+
+By default, connectors (the lines drawn between layers) are 1 pixel wide and black.
+You can customize their appearance using ``connector_fill`` and ``connector_width``.
+This is particularly useful when highlighting the flow of data through a complex
+network, or when dealing with skip connections in a residual model.
+
+Here, we render a residual block with a bold red connector of width 3 to make the
+data paths stand out.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A classic ResNet-style block with a plain identity shortcut."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass, with a skip connection around conv1/bn1/relu/conv2/bn2."""
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return self.relu(out)
+
+
+model = ResidualBlock(channels=8)
+
+input_shape = (1, 8, 16, 16)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.BatchNorm2d]["fill"] = "#009E73"
+color_map[nn.ReLU]["fill"] = "#56B4E9"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="graph",
+    show_neurons=False,
+    color_map=color_map,
+    layer_spacing=60,
+    connector_fill="red",
+    connector_width=3,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_connector_style_lenet.py
+++ b/docs/examples/lenet_style/plot_connector_style_lenet.py
@@ -1,0 +1,64 @@
+"""Connector Styling
+=======================================
+
+By default, connectors (the lines drawn between layers) are 1 pixel wide and black.
+You can customize their appearance using ``connector_fill`` and ``connector_width``.
+This is particularly useful when highlighting the flow of data through a complex
+network, or when dealing with skip connections in a residual model.
+
+Here, we render a residual block with a bold red connector of width 3 to make the
+data paths stand out.
+"""  # noqa: D205
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A classic ResNet-style block with a plain identity shortcut."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Define the forward pass, with a skip connection around conv1/bn1/relu/conv2/bn2."""
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out = out + identity
+        return self.relu(out)
+
+
+model = ResidualBlock(channels=8)
+
+input_shape = (1, 8, 16, 16)
+
+color_map: dict = defaultdict(dict)
+color_map[nn.Conv2d]["fill"] = "#E69F00"
+color_map[nn.BatchNorm2d]["fill"] = "#009E73"
+color_map[nn.ReLU]["fill"] = "#56B4E9"
+
+img = visualtorch.render(
+    model,
+    input_shape,
+    style="lenet",
+    color_map=color_map,
+    connector_fill="red",
+    connector_width=3,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
Fixes #139
### Description
This PR adds three new dedicated examples to the gallery to demonstrate the `connector_fill` and `connector_width` parameters, which previously only had incidental use buried in other examples. 

To ensure the connector styling is clearly visible, each example implements a simple `ResidualBlock` with a skip connection. The connectors are styled with a bold red color (`connector_fill="red"`) and increased thickness (`connector_width=3`).

### Changes made:
* Added `docs/examples/graph/plot_connector_style_graph.py`
* Added `docs/examples/flow/plot_connector_style_flow.py`
* Added `docs/examples/lenet_style/plot_connector_style_lenet.py`

### Testing
- [x] Ran all three scripts locally and confirmed they execute without error and display the models correctly.
- [x] Ran `pre-commit run --all-files` successfully.
- [x] Ran `pytest tests/` successfully.
