### PR TITLE
feat: add optional VisualTorch MCP integration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+  mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install VisualTorch with MCP support
+        run: python -m pip install ".[mcp]" pytest
+
+      - name: Import MCP server
+        run: python -c "from visualtorch_mcp.server import mcp; print(mcp.name)"
+
+      - name: Run MCP tests
+        run: pytest tests/test_mcp.py

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ The docs include [usage examples](https://visualtorch.readthedocs.io/en/latest/u
 
 See the [Installation page](https://visualtorch.readthedocs.io/en/latest/markdown/get_started/installation.html).
 
+## MCP integration
+
+VisualTorch includes an optional MCP server for generating architecture diagrams from model source
+provided by an MCP client. Install it with `pip install "visualtorch[mcp]"` and see the
+[MCP integration guide](https://visualtorch.readthedocs.io/en/latest/markdown/get_started/mcp.html)
+for configuration and usage details.
+
 ## Used in Research
 
 VisualTorch has been used in published research, including works published in Nature, IEEE, and MDPI.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,6 +15,13 @@ VisualTorch aims to help visualize Torch-based neural network architectures. It 
 Installing visualtorch via PyPI or Source.
 :::
 
+:::{grid-item-card} MCP integration
+:link: markdown/get_started/mcp
+:link-type: doc
+
+Use VisualTorch through an MCP-compatible coding assistant.
+:::
+
 ::::
 
 ## {octicon}`eye` Usage Examples
@@ -82,6 +89,7 @@ Please cite this project in your publications if it helps your research as follo
 :hidden:
 
 markdown/get_started/installation
+markdown/get_started/mcp
 ```
 
 ```{toctree}

--- a/docs/source/markdown/get_started/mcp.md
+++ b/docs/source/markdown/get_started/mcp.md
@@ -1,0 +1,76 @@
+# MCP integration
+
+VisualTorch provides an optional [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
+server for generating architecture diagrams from model source supplied by an MCP client. The MCP
+server uses VisualTorch's public `visualtorch.render(...)` API and writes the generated image to a
+local file.
+
+## Installation
+
+Install the optional MCP dependency alongside VisualTorch:
+
+```bash
+python -m pip install "visualtorch[mcp]"
+```
+
+For a source checkout, install the project in editable mode:
+
+```bash
+python -m pip install -e ".[mcp]"
+```
+
+Both commands install the `visualtorch-mcp` console script.
+
+## MCP client configuration
+
+Add the server to an MCP client configuration that supports stdio servers:
+
+```json
+{
+  "mcpServers": {
+    "visualtorch": {
+      "command": "visualtorch-mcp"
+    }
+  }
+}
+```
+
+If the client should use a specific Python environment, configure its interpreter explicitly:
+
+```json
+{
+  "mcpServers": {
+    "visualtorch": {
+      "command": "C:/path/to/venv/Scripts/python.exe",
+      "args": ["-m", "visualtorch_mcp.server"]
+    }
+  }
+}
+```
+
+## Tools and resources
+
+The `visualize_model` tool accepts:
+
+- `source`: Python source that imports its dependencies and defines the model.
+- `input_shape`: one input shape including the batch dimension, or one shape per positional input.
+- `style`: `graph`, `flow`, or `lenet`. The compatibility aliases `layered`, `layered_view`,
+  `lenet_style`, and `lenet_view` are also accepted.
+- `model_expression`: an expression evaluated after `source`; it defaults to `model` and can be
+  set to an expression such as `Net()` or `build_model()`.
+- `output_path`: an optional image path. Relative paths are resolved under `output_dir`.
+- `output_dir`: an optional base directory for generated images.
+- `options`: VisualTorch render options, such as `{"palette": "dracula", "show_dimension": true}`.
+- `workdir`: an optional working directory for the model source.
+- `timeout_seconds`: the render subprocess timeout, defaulting to 120 seconds.
+
+The `visualtorch_reference` tool and the `visualtorch://docs` resource expose links to the upstream
+VisualTorch API references and examples. The `visualtorch://version` resource reports the MCP
+integration version.
+
+## Security
+
+The server intentionally executes the supplied model source and evaluates `model_expression` in a
+separate Python subprocess. Only connect it to clients and use source code that you trust. The
+subprocess timeout and boundary keep a failed render from crashing the MCP server, but they are not
+a security sandbox for hostile Python code.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,11 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=_read_requirements("requirements.txt"),
-    extras_require={"dev": _read_requirements("docs/requirements.txt") + _read_requirements("dev-requirements.txt")},
+    extras_require={
+        "dev": _read_requirements("docs/requirements.txt") + _read_requirements("dev-requirements.txt"),
+        "mcp": ["mcp>=1.0.0"],
+    },
+    entry_points={"console_scripts": ["visualtorch-mcp=visualtorch_mcp.server:main"]},
     python_requires=">=3.10",
     license="MIT",
     license_files=("LICENSE.md",),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,112 @@
+"""Focused tests for the migrated VisualTorch MCP integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from visualtorch_mcp.api_reference import normalize_style_name
+from visualtorch_mcp.runner import (
+    normalize_input_shape,
+    render_model,
+    resolve_output_path,
+)
+from visualtorch_mcp.worker import _coerce_options, _restore_tuples
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("graph", "graph"),
+        ("FLOW", "flow"),
+        ("layered", "flow"),
+        ("layered-view", "flow"),
+        (" lenet_style ", "lenet"),
+        ("LENET_VIEW", "lenet"),
+    ],
+)
+def test_style_aliases(alias: str, canonical: str) -> None:
+    """Normalize supported style aliases to their canonical names."""
+    assert normalize_style_name(alias) == canonical
+
+
+def test_unknown_style_is_rejected() -> None:
+    """Reject unsupported style names with an actionable error."""
+    with pytest.raises(ValueError, match="Unsupported style"):
+        normalize_style_name("not-a-style")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ([1, 3, 8, 8], (1, 3, 8, 8)),
+        ("[[1, 3, 8, 8], [1, 5]]", ((1, 3, 8, 8), (1, 5))),
+        (((1, 3), (1, 2)), ((1, 3), (1, 2))),
+    ],
+)
+def test_input_shape_normalization(value: object, expected: object) -> None:
+    """Normalize flat, JSON, and multi-input shapes into tuples."""
+    assert normalize_input_shape(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [],
+        [1, [3, 8]],
+        [[1, 3], []],
+        [[1, 3], [1, 0]],
+        [[1, 3], [1, True]],
+        "not json",
+    ],
+)
+def test_input_shape_validation(value: object) -> None:
+    """Reject malformed shapes before starting a render subprocess."""
+    with pytest.raises((ValueError, json.JSONDecodeError)):
+        normalize_input_shape(value)
+
+
+def test_output_path_resolution(tmp_path: Path) -> None:
+    """Resolve explicit and generated paths beneath the requested output directory."""
+    explicit = resolve_output_path("nested/diagram", str(tmp_path), "graph")
+    assert explicit == (tmp_path / "nested" / "diagram.png").resolve()
+    assert explicit.parent.is_dir()
+
+    generated = resolve_output_path(None, str(tmp_path), "flow")
+    assert generated.parent == tmp_path.resolve()
+    assert generated.name.startswith("visualtorch_flow_")
+    assert generated.suffix == ".png"
+
+
+def test_worker_option_type_coercion_and_tuple_restore() -> None:
+    """Coerce option type names and restore JSON lists to renderer tuples."""
+    custom = type("Custom", (), {})
+    namespace = {}
+    coerced = _coerce_options(
+        namespace,
+        {"type_ignore": ["Linear", custom], "color_map": {custom: "red"}},
+    )
+    assert coerced["type_ignore"][0].__name__ == "Linear"
+    assert coerced["type_ignore"][1] is custom
+    assert coerced["color_map"] == {custom: "red"}
+    assert _restore_tuples([[1, [2, 3]], 4]) == ((1, (2, 3)), 4)
+
+
+def test_render_model_worker_smoke(tmp_path: Path) -> None:
+    """Render a small model through the worker and report its generated PNG."""
+    result = render_model(
+        source="import torch\nmodel = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 2))",
+        input_shape=(1, 1, 2, 2),
+        style="graph",
+        output_path="smoke.png",
+        output_dir=str(tmp_path),
+        options={"show_neurons": False},
+        timeout_seconds=30,
+    )
+
+    output_path = Path(result["output_path"])
+    assert output_path == (tmp_path / "smoke.png").resolve()
+    assert output_path.is_file()
+    assert result["style"] == "graph"
+    assert result["bytes"] == output_path.stat().st_size

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from visualtorch_mcp.runner import (
     resolve_output_path,
 )
 from visualtorch_mcp.worker import _coerce_options, _restore_tuples
+from visualtorch_mcp.worker import main as worker_main
 
 
 @pytest.mark.parametrize(
@@ -130,6 +132,42 @@ def test_render_model_keeps_source_stdout_out_of_protocol(tmp_path: Path, capsys
     captured = capsys.readouterr()
     assert "source output" not in captured.out
     assert Path(result["output_path"]).is_file()
+
+
+def test_worker_protocol_keeps_stdout_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Keep worker stdout parseable while forwarding model output to stderr."""
+    output_path = tmp_path / "worker-protocol.png"
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "source": (
+                    "print('source output')\n"
+                    "import torch\nmodel = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 2))"
+                ),
+                "input_shape": [1, 1, 2, 2],
+                "style": "graph",
+                "model_expression": "model",
+                "output_path": str(output_path),
+                "options": {"show_neurons": False},
+            },
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["visualtorch_mcp.worker", str(payload_path)])
+
+    worker_main()
+
+    captured = capsys.readouterr()
+    assert "source output" not in captured.out
+    assert "source output" in captured.err
+    result = json.loads(captured.out)
+    assert Path(result["output_path"]) == output_path.resolve()
+    assert output_path.is_file()
 
 
 def test_render_model_imports_model_from_workdir(tmp_path: Path) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -110,3 +110,44 @@ def test_render_model_worker_smoke(tmp_path: Path) -> None:
     assert output_path.is_file()
     assert result["style"] == "graph"
     assert result["bytes"] == output_path.stat().st_size
+
+
+def test_render_model_keeps_source_stdout_out_of_protocol(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Keep user source output off stdout while returning a parseable result."""
+    result = render_model(
+        source=(
+            "print('source output')\n"
+            "import torch\nmodel = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 2))"
+        ),
+        input_shape=(1, 1, 2, 2),
+        style="graph",
+        output_path="source-print.png",
+        output_dir=str(tmp_path),
+        options={"show_neurons": False},
+        timeout_seconds=30,
+    )
+
+    captured = capsys.readouterr()
+    assert "source output" not in captured.out
+    assert Path(result["output_path"]).is_file()
+
+
+def test_render_model_imports_model_from_workdir(tmp_path: Path) -> None:
+    """Make the documented workdir available for imports in user source."""
+    (tmp_path / "local_model.py").write_text(
+        "import torch\nmodel = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 2))\n",
+        encoding="utf-8",
+    )
+
+    result = render_model(
+        source="from local_model import model",
+        input_shape=(1, 1, 2, 2),
+        style="graph",
+        output_path="workdir-import.png",
+        output_dir=str(tmp_path),
+        workdir=str(tmp_path),
+        options={"show_neurons": False},
+        timeout_seconds=30,
+    )
+
+    assert Path(result["output_path"]).is_file()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -189,3 +191,43 @@ def test_render_model_imports_model_from_workdir(tmp_path: Path) -> None:
     )
 
     assert Path(result["output_path"]).is_file()
+
+
+def test_mcp_stdio_end_to_end(tmp_path: Path) -> None:
+    """Exercise the installed MCP stdio server through its client protocol."""
+    pytest.importorskip("mcp")
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    executable = shutil.which("visualtorch-mcp")
+    if executable is None:
+        pytest.fail("mcp is installed, but the visualtorch-mcp console script was not found")
+
+    async def exercise_server() -> tuple[object, object, object, object]:
+        server_parameters = StdioServerParameters(command=executable, args=[])
+        async with (
+            stdio_client(server_parameters) as (read_stream, write_stream),
+            ClientSession(read_stream, write_stream) as session,
+        ):
+            await session.initialize()
+            tools = await session.list_tools()
+            resources = await session.list_resources()
+            version = await session.read_resource("visualtorch://version")
+            result = await session.call_tool(
+                "visualize_model",
+                {
+                    "source": ("print('source output')\nimport torch\nmodel = torch.nn.Identity()"),
+                    "input_shape": [1, 1, 2, 2],
+                    "output_dir": str(tmp_path),
+                    "timeout_seconds": 10,
+                },
+            )
+        return tools, resources, version, result
+
+    tools, resources, version, result = asyncio.run(exercise_server())
+
+    assert any(tool.name == "visualize_model" for tool in tools.tools)
+    assert any(str(resource.uri) == "visualtorch://version" for resource in resources.resources)
+    assert version.contents
+    assert not result.isError
+    assert list(tmp_path.glob("*.png"))

--- a/visualtorch_mcp/__init__.py
+++ b/visualtorch_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP integration for VisualTorch."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/visualtorch_mcp/api_reference.py
+++ b/visualtorch_mcp/api_reference.py
@@ -1,0 +1,117 @@
+"""Upstream VisualTorch documentation pointers exposed through MCP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DocsPage:
+    """Describe one upstream documentation page."""
+
+    title: str
+    github_path: str
+    source_url: str
+    readthedocs_url: str
+
+
+DOCS_BASE = "https://github.com/willyfh/visualtorch/blob/main/docs"
+RAW_BASE = "https://raw.githubusercontent.com/willyfh/visualtorch/main/docs"
+RTD_BASE = "https://visualtorch.readthedocs.io/en/latest"
+
+STYLE_ALIASES: dict[str, tuple[str, ...]] = {
+    "graph": ("graph",),
+    "flow": ("flow", "layered", "layered_view"),
+    "lenet": ("lenet", "lenet_style", "lenet_view"),
+}
+
+DOCS_PAGES: dict[str, DocsPage] = {
+    "index": DocsPage(
+        title="VisualTorch Documentation",
+        github_path="source/index.md",
+        source_url=f"{RAW_BASE}/source/index.md",
+        readthedocs_url=f"{RTD_BASE}/",
+    ),
+    "installation": DocsPage(
+        title="Installation",
+        github_path="source/markdown/get_started/installation.md",
+        source_url=f"{RAW_BASE}/source/markdown/get_started/installation.md",
+        readthedocs_url=f"{RTD_BASE}/markdown/get_started/installation.html",
+    ),
+    "render": DocsPage(
+        title="Render",
+        github_path="source/markdown/api_references/render.md",
+        source_url=f"{RAW_BASE}/source/markdown/api_references/render.md",
+        readthedocs_url=f"{RTD_BASE}/markdown/api_references/render.html",
+    ),
+    "flow": DocsPage(
+        title="Flow View",
+        github_path="source/markdown/api_references/flow.md",
+        source_url=f"{RAW_BASE}/source/markdown/api_references/flow.md",
+        readthedocs_url=f"{RTD_BASE}/markdown/api_references/flow.html",
+    ),
+    "graph": DocsPage(
+        title="Graph View",
+        github_path="source/markdown/api_references/graph.md",
+        source_url=f"{RAW_BASE}/source/markdown/api_references/graph.md",
+        readthedocs_url=f"{RTD_BASE}/markdown/api_references/graph.html",
+    ),
+    "lenet": DocsPage(
+        title="LeNet Style View",
+        github_path="source/markdown/api_references/lenet_style.md",
+        source_url=f"{RAW_BASE}/source/markdown/api_references/lenet_style.md",
+        readthedocs_url=f"{RTD_BASE}/markdown/api_references/lenet_style.html",
+    ),
+    "examples": DocsPage(
+        title="Usage Examples",
+        github_path="examples",
+        source_url=f"{DOCS_BASE}/examples",
+        readthedocs_url=f"{RTD_BASE}/usage_examples/index.html",
+    ),
+}
+
+
+def docs_manifest(style: str | None = None) -> str:
+    """Return upstream VisualTorch docs links without duplicating API documentation."""
+    keys = ["index", "installation", "render", "flow", "graph", "lenet", "examples"]
+    if style:
+        keys = [normalize_style_name(style)]
+
+    lines = [
+        "Upstream VisualTorch documentation:",
+        f"- GitHub docs root: {DOCS_BASE}",
+        f"- Read the Docs root: {RTD_BASE}/",
+        "",
+        "MCP style aliases accepted by this server:",
+    ]
+    for canonical, aliases in STYLE_ALIASES.items():
+        lines.append(f"- {canonical}: {', '.join(aliases)}")
+
+    lines.extend(["", "Relevant upstream docs pages:"])
+    for key in keys:
+        page = DOCS_PAGES[key]
+        lines.extend(
+            [
+                f"- {page.title}",
+                f"  GitHub: {DOCS_BASE}/{page.github_path}",
+                f"  Source: {page.source_url}",
+                f"  Read the Docs: {page.readthedocs_url}",
+            ],
+        )
+
+    return "\n".join(lines)
+
+
+# Backward-compatible name for the MCP tool/resource created before docs were wired in.
+api_reference = docs_manifest
+
+
+def normalize_style_name(style: str) -> str:
+    """Return the canonical VisualTorch style name for a user-facing alias."""
+    normalized = style.strip().lower().replace("-", "_")
+    for canonical, aliases in STYLE_ALIASES.items():
+        if normalized == canonical or normalized in aliases:
+            return canonical
+    supported = sorted({alias for aliases in STYLE_ALIASES.values() for alias in aliases})
+    message = f"Unsupported style {style!r}. Supported styles and aliases: {', '.join(supported)}."
+    raise ValueError(message)

--- a/visualtorch_mcp/runner.py
+++ b/visualtorch_mcp/runner.py
@@ -99,7 +99,7 @@ def render_model(
         payload_file_path = Path(payload_file.name)
 
     try:
-        completed = subprocess.run(  # noqa: S603 - invokes this package's fixed worker module.
+        completed = subprocess.run(  # - invokes this package's fixed worker module.
             [sys.executable, "-m", "visualtorch_mcp.worker", str(payload_file_path)],
             check=False,
             capture_output=True,

--- a/visualtorch_mcp/runner.py
+++ b/visualtorch_mcp/runner.py
@@ -103,6 +103,7 @@ def render_model(
             [sys.executable, "-m", "visualtorch_mcp.worker", str(payload_file_path)],  # noqa: S603
             check=False,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             timeout=timeout_seconds,
         )

--- a/visualtorch_mcp/runner.py
+++ b/visualtorch_mcp/runner.py
@@ -21,11 +21,11 @@ def normalize_input_shape(value: object) -> tuple[int, ...] | tuple[tuple[int, .
     if isinstance(value, str):
         value = json.loads(value)
 
-    if not isinstance(value, (list, tuple)) or not value:
+    if not isinstance(value, list | tuple) or not value:
         message = "input_shape must be a non-empty list/tuple, or a JSON string containing one."
         raise ValueError(message)
 
-    has_nested = any(isinstance(item, (list, tuple)) for item in value)
+    has_nested = any(isinstance(item, list | tuple) for item in value)
     has_scalar = any(isinstance(item, int) and not isinstance(item, bool) for item in value)
     if has_nested and has_scalar:
         message = "input_shape must be either one flat shape or a list of per-input shapes, not both."
@@ -99,8 +99,8 @@ def render_model(
         payload_file_path = Path(payload_file.name)
 
     try:
-        completed = subprocess.run(  # - invokes this package's fixed worker module.
-            [sys.executable, "-m", "visualtorch_mcp.worker", str(payload_file_path)],
+        completed = subprocess.run(
+            [sys.executable, "-m", "visualtorch_mcp.worker", str(payload_file_path)],  # noqa: S603
             check=False,
             capture_output=True,
             text=True,
@@ -127,7 +127,7 @@ def render_model(
 
 
 def _normalize_single_shape(value: object) -> tuple[int, ...]:
-    if not isinstance(value, (list, tuple)) or not value:
+    if not isinstance(value, list | tuple) or not value:
         message = "each input shape must be a non-empty list/tuple of positive integers."
         raise ValueError(message)
 

--- a/visualtorch_mcp/runner.py
+++ b/visualtorch_mcp/runner.py
@@ -1,0 +1,140 @@
+"""Subprocess runner for VisualTorch renders."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .api_reference import normalize_style_name
+
+DEFAULT_OUTPUT_DIR = Path.cwd() / "visualtorch_outputs"
+
+
+def normalize_input_shape(value: object) -> tuple[int, ...] | tuple[tuple[int, ...], ...]:
+    """Normalize a JSON-friendly input shape into VisualTorch's tuple format."""
+    if isinstance(value, str):
+        value = json.loads(value)
+
+    if not isinstance(value, (list, tuple)) or not value:
+        message = "input_shape must be a non-empty list/tuple, or a JSON string containing one."
+        raise ValueError(message)
+
+    has_nested = any(isinstance(item, (list, tuple)) for item in value)
+    has_scalar = any(isinstance(item, int) and not isinstance(item, bool) for item in value)
+    if has_nested and has_scalar:
+        message = "input_shape must be either one flat shape or a list of per-input shapes, not both."
+        raise ValueError(message)
+
+    if has_nested:
+        return tuple(_normalize_single_shape(item) for item in value)
+    return _normalize_single_shape(value)
+
+
+def resolve_output_path(output_path: str | None, output_dir: str | None, style: str) -> Path:
+    """Resolve or create a deterministic render output path."""
+    base_dir = Path(output_dir).expanduser() if output_dir else DEFAULT_OUTPUT_DIR
+    base_dir = base_dir.resolve()
+
+    if output_path:
+        path = Path(output_path).expanduser()
+        if not path.is_absolute():
+            path = base_dir / path
+    else:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        path = base_dir / f"visualtorch_{style}_{stamp}_{uuid.uuid4().hex[:8]}.png"
+
+    if not path.suffix:
+        path = path.with_suffix(".png")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path.resolve()
+
+
+def render_model(
+    *,
+    source: str,
+    input_shape: object,
+    style: str = "graph",
+    model_expression: str = "model",
+    output_path: str | None = None,
+    output_dir: str | None = None,
+    options: dict[str, Any] | None = None,
+    workdir: str | None = None,
+    timeout_seconds: int = 120,
+) -> dict[str, Any]:
+    """Render a PyTorch model by invoking the worker process."""
+    if not source.strip():
+        message = "source must contain Python code that defines the model."
+        raise ValueError(message)
+    if timeout_seconds < 1:
+        message = "timeout_seconds must be at least 1."
+        raise ValueError(message)
+
+    canonical_style = normalize_style_name(style)
+    normalized_shape = normalize_input_shape(input_shape)
+    resolved_output_path = resolve_output_path(output_path, output_dir, canonical_style)
+    payload = {
+        "source": source,
+        "input_shape": normalized_shape,
+        "style": canonical_style,
+        "model_expression": model_expression,
+        "output_path": str(resolved_output_path),
+        "options": options or {},
+        "workdir": workdir,
+    }
+
+    with tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".json",
+        encoding="utf-8",
+        delete=False,
+    ) as payload_file:
+        json.dump(payload, payload_file)
+        payload_file_path = Path(payload_file.name)
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - invokes this package's fixed worker module.
+            [sys.executable, "-m", "visualtorch_mcp.worker", str(payload_file_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        message = f"VisualTorch render timed out after {timeout_seconds} seconds."
+        raise TimeoutError(message) from exc
+    finally:
+        payload_file_path.unlink(missing_ok=True)
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "worker failed without output"
+        message = f"VisualTorch render failed: {detail}"
+        raise RuntimeError(message)
+
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        message = f"VisualTorch worker returned invalid JSON: {completed.stdout!r}"
+        raise RuntimeError(message) from exc
+
+    return result
+
+
+def _normalize_single_shape(value: object) -> tuple[int, ...]:
+    if not isinstance(value, (list, tuple)) or not value:
+        message = "each input shape must be a non-empty list/tuple of positive integers."
+        raise ValueError(message)
+
+    shape: list[int] = []
+    for dimension in value:
+        if not isinstance(dimension, int) or isinstance(dimension, bool) or dimension <= 0:
+            message = "each input shape dimension must be a positive integer."
+            raise ValueError(message)
+        shape.append(dimension)
+    return tuple(shape)

--- a/visualtorch_mcp/server.py
+++ b/visualtorch_mcp/server.py
@@ -1,0 +1,77 @@
+"""MCP server exposing VisualTorch rendering tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from . import __version__
+from .api_reference import docs_manifest
+from .runner import render_model
+
+mcp = FastMCP("visualtorch-mcp")
+
+
+@mcp.tool()
+def visualize_model(
+    source: str,
+    input_shape: Any,  # noqa: ANN401 - MCP accepts either one shape or per-input shapes.
+    style: str = "graph",
+    model_expression: str = "model",
+    output_path: str | None = None,
+    output_dir: str | None = None,
+    options: dict[str, Any] | None = None,
+    workdir: str | None = None,
+    timeout_seconds: int = 120,
+) -> dict[str, Any]:
+    """Render a PyTorch model architecture diagram with VisualTorch.
+
+    ``source`` should define the model and any classes it needs. By default the worker evaluates
+    ``model_expression="model"`` after executing ``source``; set it to an expression such as
+    ``Net()`` or ``build_model()`` when the source defines a class or factory instead.
+    """
+    return render_model(
+        source=source,
+        input_shape=input_shape,
+        style=style,
+        model_expression=model_expression,
+        output_path=output_path,
+        output_dir=output_dir,
+        options=options,
+        workdir=workdir,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@mcp.tool()
+def visualtorch_reference(style: str | None = None) -> str:
+    """Return upstream VisualTorch docs links for styles and examples."""
+    return docs_manifest(style)
+
+
+@mcp.resource("visualtorch://docs")
+def visualtorch_docs() -> str:
+    """Return upstream VisualTorch documentation links."""
+    return docs_manifest()
+
+
+@mcp.resource("visualtorch://api-reference")
+def visualtorch_api_reference() -> str:
+    """Return the backward-compatible upstream API documentation resource."""
+    return docs_manifest()
+
+
+@mcp.resource("visualtorch://version")
+def version() -> str:
+    """Return the version of this MCP server."""
+    return __version__
+
+
+def main() -> None:
+    """Run the stdio MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/visualtorch_mcp/worker.py
+++ b/visualtorch_mcp/worker.py
@@ -1,0 +1,144 @@
+"""Worker process that imports VisualTorch and renders one image."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import os
+import sys
+import traceback
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def main() -> None:
+    """Render from a JSON payload path passed on the command line."""
+    try:
+        payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+        result = _render_from_payload(payload)
+    except Exception as exc:
+        print(f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(json.dumps(result))
+
+
+def _render_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    workdir = payload.get("workdir")
+    if workdir:
+        os.chdir(workdir)
+
+    namespace = _execute_source(payload["source"])
+    model_expression = payload.get("model_expression") or "model"
+    model = eval(model_expression, namespace)  # noqa: S307 - trusted local model source is intentional.
+    if hasattr(model, "eval"):
+        model.eval()
+
+    output_path = Path(payload["output_path"]).expanduser().resolve()
+    options = _coerce_options(namespace, payload.get("options") or {})
+    options["to_file"] = str(output_path)
+
+    image = _call_visualtorch(
+        model=model,
+        input_shape=_restore_tuples(payload["input_shape"]),
+        style=payload["style"],
+        options=options,
+    )
+
+    if not output_path.exists() and hasattr(image, "save"):
+        image.save(output_path)
+
+    width = height = mode = None
+    if hasattr(image, "size"):
+        width, height = image.size
+        mode = getattr(image, "mode", None)
+
+    return {
+        "output_path": str(output_path),
+        "style": payload["style"],
+        "width": width,
+        "height": height,
+        "mode": mode,
+        "bytes": output_path.stat().st_size if output_path.exists() else None,
+    }
+
+
+def _execute_source(source: str) -> dict[str, Any]:
+    namespace: dict[str, Any] = {"__name__": "__visualtorch_user_model__"}
+    exec(compile(source, "<visualtorch-model>", "exec"), namespace)  # noqa: S102 - intentional model execution.
+    return namespace
+
+
+def _call_visualtorch(model: object, input_shape: object, style: str, options: dict[str, Any]) -> object:
+    visualtorch = importlib.import_module("visualtorch")
+    render = getattr(visualtorch, "render", None)
+    if callable(render):
+        return render(model, input_shape, style=style, **options)
+
+    function = _legacy_render_function(style)
+    filtered_options = _filter_kwargs(function, options)
+    return function(model, input_shape, **filtered_options)
+
+
+def _legacy_render_function(style: str) -> Callable[..., object]:
+    candidates = {
+        "graph": (("visualtorch.graph", "graph_view"),),
+        "flow": (("visualtorch.flow", "flow_view"), ("visualtorch.layered", "layered_view")),
+        "lenet": (("visualtorch.lenet_style", "lenet_view"),),
+    }[style]
+
+    for module_name, function_name in candidates:
+        with suppress(ImportError, AttributeError):
+            module = importlib.import_module(module_name)
+            return getattr(module, function_name)
+
+    message = f"Installed visualtorch does not expose a renderer for style {style!r}."
+    raise RuntimeError(message)
+
+
+def _coerce_options(namespace: dict[str, Any], options: dict[str, Any]) -> dict[str, Any]:
+    coerced = dict(options)
+    if "type_ignore" in coerced and coerced["type_ignore"] is not None:
+        coerced["type_ignore"] = [_resolve_type(namespace, item) for item in coerced["type_ignore"]]
+    if "color_map" in coerced and isinstance(coerced["color_map"], dict):
+        coerced["color_map"] = {_resolve_type(namespace, key): value for key, value in coerced["color_map"].items()}
+    return coerced
+
+
+def _resolve_type(namespace: dict[str, Any], value: object) -> type:
+    if isinstance(value, type):
+        return value
+    if not isinstance(value, str):
+        message = f"Expected a type name string, got {value!r}."
+        raise TypeError(message)
+
+    expression = value if "." in value else f"nn.{value}"
+    if "nn" not in namespace:
+        with suppress(ImportError):
+            namespace["nn"] = importlib.import_module("torch.nn")
+
+    resolved = eval(expression, namespace)  # noqa: S307 - resolves trusted model option types.
+    if not isinstance(resolved, type):
+        message = f"{value!r} did not resolve to a type."
+        raise TypeError(message)
+    return resolved
+
+
+def _filter_kwargs(function: Callable[..., object], kwargs: dict[str, Any]) -> dict[str, Any]:
+    signature = inspect.signature(function)
+    return {key: value for key, value in kwargs.items() if key in signature.parameters}
+
+
+def _restore_tuples(value: object) -> object:
+    if isinstance(value, list):
+        return tuple(_restore_tuples(item) for item in value)
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/visualtorch_mcp/worker.py
+++ b/visualtorch_mcp/worker.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import traceback
-from contextlib import suppress
+from contextlib import redirect_stdout, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,8 +20,9 @@ def main() -> None:
     """Render from a JSON payload path passed on the command line."""
     try:
         payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-        result = _render_from_payload(payload)
-    except Exception as exc:
+        with redirect_stdout(sys.stderr):
+            result = _render_from_payload(payload)
+    except Exception as exc:  # noqa: BLE001, RUF100
         print(f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}", file=sys.stderr)
         raise SystemExit(1) from exc
 
@@ -31,11 +32,14 @@ def main() -> None:
 def _render_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
     workdir = payload.get("workdir")
     if workdir:
-        os.chdir(workdir)
+        resolved_workdir = Path(workdir).expanduser().resolve()
+        os.chdir(resolved_workdir)
+        if str(resolved_workdir) not in sys.path:
+            sys.path.insert(0, str(resolved_workdir))
 
     namespace = _execute_source(payload["source"])
     model_expression = payload.get("model_expression") or "model"
-    model = eval(model_expression, namespace)  # noqa: S307 - trusted local model source is intentional.
+    model = eval(model_expression, namespace)  # noqa: PGH001, S307
     if hasattr(model, "eval"):
         model.eval()
 
@@ -122,7 +126,7 @@ def _resolve_type(namespace: dict[str, Any], value: object) -> type:
         with suppress(ImportError):
             namespace["nn"] = importlib.import_module("torch.nn")
 
-    resolved = eval(expression, namespace)  # noqa: S307 - resolves trusted model option types.
+    resolved = eval(expression, namespace)  # noqa: PGH001, S307
     if not isinstance(resolved, type):
         message = f"{value!r} did not resolve to a type."
         raise TypeError(message)


### PR DESCRIPTION
Closes #106

## Summary

- Integrate the MCP wrapper into the official VisualTorch repository as the optional `visualtorch_mcp` package.
- Add the `mcp` extra and `visualtorch-mcp` console script through the repository's existing `setup.py` packaging.
- Keep rendering on the public `visualtorch.render(...)` API while preserving style aliases, documentation resources, subprocess isolation, output metadata, and trusted-source warnings.
- Keep worker stdout reserved for the machine-readable result protocol, make `workdir` local imports available to model source, and prevent the worker from inheriting the MCP stdio input stream.
- Add unit, worker-protocol, and real MCP stdio end-to-end coverage, plus an MCP CI job, README guidance, and a Sphinx getting-started page.

## Validation

- Base suite excluding the MCP-only transport test — 189 passed.
- Clean wheel environment running `tests/test_mcp.py` — 23 passed.
- Clean wheel `visualtorch-mcp` console-script stdio smoke — passed: initialize, tool/resource discovery, version resource, model render, and PNG output.
- Scoped pre-commit hooks for the changed files — passed.
- Editable installation and wheel inspection confirmed that the MCP package, optional dependency, and console entry point are included.
