### PR TITLE
fix: apply connector style to regular funnels

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -702,6 +702,18 @@ def test_flow_view_connector_fill_none_uses_box_outline(residual_model: nn.Modul
     assert img_default.tobytes() == img_explicit_none.tobytes()
 
 
+def test_flow_view_connector_style_applies_to_regular_funnels(sequential_model: nn.Sequential) -> None:
+    """Explicit connector styling should affect adjacent-layer funnels, not only skip edges."""
+    img_default = flow_view(sequential_model, input_shape=(1, 3, 224, 224))
+    img_custom = flow_view(
+        sequential_model,
+        input_shape=(1, 3, 224, 224),
+        connector_fill="red",
+        connector_width=3,
+    )
+    assert img_custom.tobytes() != img_default.tobytes()
+
+
 def test_flow_view_outline_width_accepted(sequential_model: nn.Sequential) -> None:
     """outline_width should visually change the rendered output."""
     img_default = flow_view(sequential_model, input_shape=(1, 3, 224, 224), draw_volume=False)

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -408,6 +408,18 @@ def test_lenet_view_connector_fill_none_uses_box_outline(residual_model: nn.Modu
     assert img_default.tobytes() == img_explicit_none.tobytes()
 
 
+def test_lenet_view_connector_style_applies_to_regular_funnels(sequential_model: nn.Sequential) -> None:
+    """Explicit connector styling should affect adjacent-layer funnels, not only skip edges."""
+    img_default = lenet_view(sequential_model, input_shape=(1, 3, 224, 224))
+    img_custom = lenet_view(
+        sequential_model,
+        input_shape=(1, 3, 224, 224),
+        connector_fill="blue",
+        connector_width=3,
+    )
+    assert img_custom.tobytes() != img_default.tobytes()
+
+
 def test_lenet_view_outline_width_accepted(sequential_model: nn.Sequential) -> None:
     """outline_width should visually change the rendered output."""
     img_default = lenet_view(sequential_model, input_shape=(1, 3, 224, 224))

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -129,9 +129,9 @@ def flow_view(
             multi-input model, where every input is always shown (omitting any of them would
             make it ambiguous which arrow belongs to which named input).
         outline_width (int, optional): Line width in pixels for the shape borders. Defaults to 1.
-        connector_fill (str or tuple, optional): Color for skip-connection lines. Can be a string
+        connector_fill (str or tuple, optional): Color for funnel and skip-connection lines. Can be a string
             or a tuple (R, G, B, A). If None, inherits the target box's outline color.
-        connector_width (int, optional): Line width in pixels for skip-connection lines. Defaults to 1.
+        connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
         legend_position (str, optional): Where to place the legend when `legend=True`. One of
             `"top-left"`, `"top-right"`, `"top-center"`, `"bottom-left"`, `"bottom-right"`, or
@@ -251,7 +251,9 @@ def flow_view(
 
     _apply_centering(column_layout, top_margin_for_skips, column_layout.diagram_height)
 
-    _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
+    _draw_funnels_and_boxes(
+        draw, architecture, column_layout, edge_to_level, draw_funnel, connector_fill, connector_width
+    )
     _draw_skip_connectors(
         draw,
         architecture,
@@ -384,9 +386,16 @@ def _apply_centering(column_layout: ColumnLayout, top_margin_for_skips: float, b
             box.x2 += column_layout.x_off
 
 
-def _draw_funnel(draw: aggdraw.Draw, start_box: VolumetricBox, end_box: VolumetricBox) -> None:
+def _draw_funnel(
+    draw: aggdraw.Draw,
+    start_box: VolumetricBox,
+    end_box: VolumetricBox,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
+) -> None:
     """Draw a tapered funnel connecting two boxes in adjacent columns."""
-    pen = aggdraw.Pen(get_rgba_tuple(end_box.outline))
+    resolved_color = connector_fill if connector_fill is not None else end_box.outline
+    pen = aggdraw.Pen(get_rgba_tuple(resolved_color), connector_width)
     start_de = getattr(start_box, "de", 0)
     end_de = getattr(end_box, "de", 0)
 
@@ -408,6 +417,8 @@ def _draw_funnels_and_boxes(
     column_layout: ColumnLayout,
     edge_to_level: dict[tuple[str, str], int],
     draw_funnel_flag: bool,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
 ) -> None:
     """Draw each column's incoming funnels, then that column's own boxes, column by column.
 
@@ -432,7 +443,7 @@ def _draw_funnels_and_boxes(
                 layer_id = layer_id_by_box[id(box)]
                 for start_id in incoming_funnels.get(layer_id, []):
                     if start_id in column_layout.id_to_box:
-                        _draw_funnel(draw, column_layout.id_to_box[start_id], box)
+                        _draw_funnel(draw, column_layout.id_to_box[start_id], box, connector_fill, connector_width)
 
         for box in column:
             box.draw(draw)

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -252,7 +252,13 @@ def flow_view(
     _apply_centering(column_layout, top_margin_for_skips, column_layout.diagram_height)
 
     _draw_funnels_and_boxes(
-        draw, architecture, column_layout, edge_to_level, draw_funnel, connector_fill, connector_width
+        draw,
+        architecture,
+        column_layout,
+        edge_to_level,
+        draw_funnel,
+        connector_fill,
+        connector_width,
     )
     _draw_skip_connectors(
         draw,

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -122,9 +122,9 @@ def lenet_view(
             more than one consumer, e.g. a residual shortcut, since dropping it would silently
             discard that edge.
         outline_width (int, optional): Line width in pixels for the shape borders. Defaults to 1.
-        connector_fill (str or tuple, optional): Color for skip-connection lines. Can be a string
+        connector_fill (str or tuple, optional): Color for funnel and skip-connection lines. Can be a string
             or a tuple (R, G, B, A). If None, inherits the target box's outline color.
-        connector_width (int, optional): Line width in pixels for skip-connection lines. Defaults to 1.
+        connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
 
     Returns:
@@ -228,7 +228,9 @@ def lenet_view(
 
     _apply_centering(column_layout, top_margin_for_skips + spread_margin / 2)
 
-    _draw_funnels_and_boxes(draw, architecture, column_layout, edge_to_level, draw_funnel)
+    _draw_funnels_and_boxes(
+        draw, architecture, column_layout, edge_to_level, draw_funnel, connector_fill, connector_width
+    )
     _draw_skip_connectors(
         draw,
         architecture,
@@ -355,9 +357,16 @@ def _apply_centering(column_layout: ColumnLayout, top_margin: float) -> None:
             box.x2 += column_layout.x_off
 
 
-def _draw_stacked_funnel(draw: aggdraw.Draw, start_box: VolumetricBox, end_box: VolumetricBox) -> None:
+def _draw_stacked_funnel(
+    draw: aggdraw.Draw,
+    start_box: VolumetricBox,
+    end_box: VolumetricBox,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
+) -> None:
     """Draw a tapered funnel connecting the outer bounds of two boxes' offset-copy stacks."""
-    pen = aggdraw.Pen(get_rgba_tuple(end_box.outline))
+    resolved_color = connector_fill if connector_fill is not None else end_box.outline
+    pen = aggdraw.Pen(get_rgba_tuple(resolved_color), connector_width)
     start_de, start_offset_z = getattr(start_box, "de", 0), getattr(start_box, "offset_z", 0)
     end_de, end_offset_z = getattr(end_box, "de", 0), getattr(end_box, "offset_z", 0)
     start_off = -start_offset_z * start_de // 2
@@ -376,6 +385,8 @@ def _draw_funnels_and_boxes(
     column_layout: ColumnLayout,
     edge_to_level: dict[tuple[str, str], int],
     draw_funnel_flag: bool,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
 ) -> None:
     """Draw each column's incoming funnels, then that column's own boxes, column by column.
 
@@ -398,7 +409,9 @@ def _draw_funnels_and_boxes(
                 layer_id = layer_id_by_box[id(box)]
                 for start_id in incoming_funnels.get(layer_id, []):
                     if start_id in column_layout.id_to_box:
-                        _draw_stacked_funnel(draw, column_layout.id_to_box[start_id], box)
+                        _draw_stacked_funnel(
+                            draw, column_layout.id_to_box[start_id], box, connector_fill, connector_width
+                        )
 
         for box in column:
             box.draw(draw)

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -229,7 +229,13 @@ def lenet_view(
     _apply_centering(column_layout, top_margin_for_skips + spread_margin / 2)
 
     _draw_funnels_and_boxes(
-        draw, architecture, column_layout, edge_to_level, draw_funnel, connector_fill, connector_width
+        draw,
+        architecture,
+        column_layout,
+        edge_to_level,
+        draw_funnel,
+        connector_fill,
+        connector_width,
     )
     _draw_skip_connectors(
         draw,
@@ -410,7 +416,11 @@ def _draw_funnels_and_boxes(
                 for start_id in incoming_funnels.get(layer_id, []):
                     if start_id in column_layout.id_to_box:
                         _draw_stacked_funnel(
-                            draw, column_layout.id_to_box[start_id], box, connector_fill, connector_width
+                            draw,
+                            column_layout.id_to_box[start_id],
+                            box,
+                            connector_fill,
+                            connector_width,
                         )
 
         for box in column:


### PR DESCRIPTION
## Summary

- apply `connector_fill` and `connector_width` to regular adjacent-layer funnels in both flow and LeNet views
- preserve the existing target-outline fallback when `connector_fill=None`
- add focused regression coverage using sequential models, which have funnels but no skip edges
- update parameter documentation to describe both funnel and skip-connection styling

## Validation

- `python -m pytest tests/test_flow.py tests/test_lenet_style.py -q` — 68 passed
- `git diff --check`
- `pre-commit run --all-files` was attempted, but this constrained runner ran out of disk while installing the hook's Node environment; project tests completed successfully before that failure

## AI assistance

AI tooling assisted with repository inspection and implementation. I reviewed the resulting code and ran the validation listed above.

Fixes #149
