### PR TITLE
Auto-assign PRs to their author when opened

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,23 @@
+name: Auto-assign PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR to its author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
## Summary
- Adds a workflow that assigns a PR to its own author as soon as it's opened, so it shows up under assignee.
- Uses `pull_request_target` rather than `pull_request` since fork PRs (most contributors here) get a read-only `GITHUB_TOKEN` under the plain `pull_request` event, which wouldn't be able to add an assignee. This is safe because the workflow never checks out or runs any code from the fork, it only calls the GitHub API with the PR's own metadata (number, author username).