### PR TITLE
Fix silently dropped edges when a model's final op is an unconsumed merge

### DIFF
--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -209,3 +209,100 @@ def test_view_renders_embedding_model_with_integer_input_dtype(embedding_model: 
     """Every style should render a token-embedding model end to end once given input_dtype."""
     img = view(embedding_model, input_shape=(1, 16), input_dtype=torch.long)  # type: ignore[operator]
     assert img is not None
+
+
+@pytest.fixture()
+def ends_in_unconsumed_merge_model() -> nn.Module:
+    """A model whose forward() returns a merge (branch + shortcut) directly - nothing downstream
+    consumes it. The tracer only turns a tensor's producers into edges when that tensor is passed
+    into another module call; a merge returned as-is has no such call, so both the branch and the
+    shortcut silently lost their edges entirely (not just a missing "merge point" indicator).
+    """  # noqa: D205
+
+    class EndsInMerge(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stem = nn.Linear(4, 4)
+            self.fc1 = nn.Linear(4, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            stem_out = self.stem(x)
+            branch = self.fc1(stem_out)
+            return branch + stem_out
+
+    return EndsInMerge()
+
+
+def test_extract_architecture_adds_output_node_for_unconsumed_final_merge(
+    ends_in_unconsumed_merge_model: nn.Module,
+) -> None:
+    """Both producers of a final, unconsumed merge should connect to a synthetic Output node."""
+    architecture = extract_architecture(ends_in_unconsumed_merge_model, (1, 4))
+    module_types = [type(layer.module).__name__ for column in architecture.columns for layer in column]
+
+    assert module_types.count("Output") == 1
+
+    output_node = next(
+        layer for column in architecture.columns for layer in column if type(layer.module).__name__ == "Output"
+    )
+    producers = {start for start, end in architecture.edges() if end == output_node.node_id}
+    assert len(producers) == 2
+
+
+def test_extract_architecture_maps_raw_input_shortcut_to_output_node() -> None:
+    """A shortcut straight from the raw input (no processing at all) should still connect to the
+    synthetic Output node, not crash or get silently dropped.
+    """  # noqa: D205
+
+    class IdentityShortcut(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.fc(x) + x
+
+    architecture = extract_architecture(IdentityShortcut(), (1, 4))
+    module_types = [type(layer.module).__name__ for column in architecture.columns for layer in column]
+    assert module_types.count("Output") == 1
+
+
+@pytest.fixture()
+def residual_model_with_trailing_layer() -> nn.Module:
+    """A residual block whose merge feeds a trailing layer - the ordinary, already-working case."""
+
+    class ResidualBlock(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stem = nn.Linear(4, 4)
+            self.fc1 = nn.Linear(4, 4)
+            self.out = nn.Linear(4, 2)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            stem_out = self.stem(x)
+            branch = self.fc1(stem_out)
+            return self.out(branch + stem_out)
+
+    return ResidualBlock()
+
+
+def test_extract_architecture_skips_output_node_for_ordinary_single_producer_output(
+    residual_model_with_trailing_layer: nn.Module,
+) -> None:
+    """A model whose final output has a single producer (the common case) needs no synthetic
+    node - nothing is hidden there, since that producer's own edges already capture the structure.
+    """  # noqa: D205
+    architecture = extract_architecture(residual_model_with_trailing_layer, (1, 4))
+    module_types = [type(layer.module).__name__ for column in architecture.columns for layer in column]
+
+    assert "Output" not in module_types
+
+
+@pytest.mark.parametrize("view", [graph_view, flow_view, lenet_view])
+def test_view_renders_unconsumed_final_merge_without_dropping_the_shortcut_edge(
+    ends_in_unconsumed_merge_model: nn.Module,
+    view: object,
+) -> None:
+    """Every style should render the fixed graph, with the shortcut edge visibly present."""
+    img = view(ends_in_unconsumed_merge_model, input_shape=(1, 4))  # type: ignore[operator]
+    assert img is not None

--- a/visualtorch/backend.py
+++ b/visualtorch/backend.py
@@ -15,12 +15,13 @@ from functools import cached_property
 import numpy as np
 from torch import nn
 
-from .utils.layer_utils import Input
+from .utils.layer_utils import Input, Output
 from .utils.recorder import trace_module_graph
 from .utils.traced_layer import TracedLayer
 from .utils.utils import InputDtype, InputShape, validate_input_dtype, validate_input_shape
 
 _INPUT_NODE_ID = "__input_dummy__"
+_OUTPUT_NODE_ID = "__output_dummy__"
 
 
 @dataclass
@@ -78,7 +79,14 @@ def extract_architecture(
     input_shapes = validate_input_shape(input_shape)
     input_dtypes = validate_input_dtype(input_dtype, len(input_shapes))
 
-    id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids = trace_module_graph(
+    (
+        id_to_module,
+        id_to_output_shape,
+        id_to_extra_output_shapes,
+        edges,
+        input_ids,
+        final_output_records,
+    ) = trace_module_graph(
         model,
         input_shapes,
         input_dtypes,
@@ -141,6 +149,19 @@ def extract_architecture(
         columns,
         direct_input_node_ids,
     )
+    # A final merge can be produced directly by a raw model input (e.g. `return self.fc(x) + x`,
+    # an identity shortcut with no processing at all) - that producer id is the recorder's raw
+    # input id, not yet in id_to_index, since only its synthetic dummy counterpart (added above)
+    # is. Map raw input ids to their synthetic dummy node ids so _add_output_dummy_layers can
+    # look either kind of producer up the same way.
+    raw_input_id_to_dummy_id = {input_id: f"{_INPUT_NODE_ID}#{i}" for i, input_id in enumerate(input_ids)}
+    id_to_index, adjacency, columns = _add_output_dummy_layers(
+        final_output_records,
+        raw_input_id_to_dummy_id,
+        id_to_index,
+        adjacency,
+        columns,
+    )
 
     id_to_column = {layer.node_id: col_idx for col_idx, column in enumerate(columns) for layer in column}
 
@@ -178,6 +199,57 @@ def _add_input_dummy_layers(
             adjacency[input_index, id_to_index[node_id]] += 1
 
     return id_to_index, adjacency, columns
+
+
+def _add_output_dummy_layers(
+    final_output_records: list[tuple[tuple[int, ...], set[str]]],
+    raw_input_id_to_dummy_id: dict[str, str],
+    id_to_index: dict[str, int],
+    adjacency: np.ndarray,
+    columns: list[list[TracedLayer]],
+) -> tuple[dict[str, int], np.ndarray, list[list[TracedLayer]]]:
+    """Append one synthetic output node per final merge the model returns directly.
+
+    A tensor with fewer than 2 producer ids needs nothing: either it's an ordinary single-module
+    output (nothing hidden) or it has no traced producer at all (e.g. a constant). Only a tensor
+    with 2+ producers - a merge the model returns with no subsequent module call to receive it -
+    would otherwise silently drop those producers' edges from the graph entirely.
+    """
+    merges = [
+        (shape, {raw_input_id_to_dummy_id.get(pid, pid) for pid in producer_ids})
+        for shape, producer_ids in final_output_records
+        if len(producer_ids) >= 2
+    ]
+    if not merges:
+        return id_to_index, adjacency, columns
+
+    n_outputs = len(merges)
+    output_dummy_node_ids = [f"{_OUTPUT_NODE_ID}#{i}" for i in range(n_outputs)]
+    output_column = [
+        TracedLayer(
+            module=Output(_output_label(i, n_outputs), shape[1] if len(shape) > 1 else None),
+            output_shape=shape,
+            node_id=output_dummy_node_ids[i],
+        )
+        for i, (shape, _producer_ids) in enumerate(merges)
+    ]
+    columns.append(output_column)
+
+    for node_id in output_dummy_node_ids:
+        id_to_index[node_id] = len(id_to_index)
+    adjacency = np.pad(adjacency, ((0, n_outputs), (0, n_outputs)), mode="constant", constant_values=0)
+
+    for i, (_shape, producer_ids) in enumerate(merges):
+        output_index = id_to_index[output_dummy_node_ids[i]]
+        for producer_id in producer_ids:
+            adjacency[id_to_index[producer_id], output_index] += 1
+
+    return id_to_index, adjacency, columns
+
+
+def _output_label(index: int, n_outputs: int) -> str:
+    """Label a synthetic output node - "output" for a single one, else indexed."""
+    return "output" if n_outputs == 1 else f"output_{index}"
 
 
 def _input_label(index: int, n_inputs: int) -> str:

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -20,6 +20,26 @@ class Input:
         return self._name
 
 
+class Output:
+    """A placeholder standing in for a final merge (e.g. a residual add) that nothing consumes.
+
+    The tracer only records an edge when a tensor is passed into another leaf module call. A
+    tensor merge (e.g. `branch + shortcut`) whose result is the model's literal return value,
+    with no subsequent module call to receive it, would otherwise silently vanish - not just
+    losing a "this is where they combine" indicator, but dropping the shortcut branch's edge
+    from the graph entirely. This placeholder gives those final producers somewhere to connect.
+    """
+
+    def __init__(self, name: str, units: int | None = None) -> None:
+        if units:
+            self.units = units
+        self._name = name
+
+    def name(self) -> str:
+        """Return layer name"""
+        return self._name
+
+
 def __getattr__(name: str) -> object:
     """Lazily provide `InputDummyLayer`, the pre-1.1 name for `Input`, with a deprecation warning."""
     if name == "InputDummyLayer":

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -130,6 +130,32 @@ def _all_tensor_shapes(obj: Any) -> list[tuple[int, ...]]:
     return []
 
 
+def _final_output_records(obj: Any) -> list[tuple[tuple[int, ...], set[str]]]:
+    """Recursively collect (shape, producer_ids) for every tensor in the model's own return value.
+
+    Mirrors `_all_tensor_shapes`'s traversal so positions line up, but also carries each tensor's
+    `_producer_ids`. A tensor with 2+ producer ids here is a merge (e.g. `branch + shortcut`)
+    that the model returns directly, with no subsequent module call to receive it - the one case
+    `_wrapped_module_call` never gets a chance to turn into edges, since edges are only recorded
+    when a tensor is passed *into* another module call.
+    """
+    if isinstance(obj, RecorderTensor):
+        return [(tuple(obj.shape), set(getattr(obj, "_producer_ids", set())))]
+    if isinstance(obj, torch.Tensor):
+        return [(tuple(obj.shape), set())]
+    if isinstance(obj, Mapping):
+        records = []
+        for value in obj.values():
+            records.extend(_final_output_records(value))
+        return records
+    if isinstance(obj, list | tuple):
+        records = []
+        for value in obj:
+            records.extend(_final_output_records(value))
+        return records
+    return []
+
+
 def _wrapped_module_call(
     id_to_module: dict[str, nn.Module],
     id_to_output_shape: dict[str, tuple[int, ...]],
@@ -216,6 +242,7 @@ def trace_module_graph(
     dict[str, tuple[tuple[int, ...], ...]],
     list[tuple[str, str]],
     list[str],
+    list[tuple[tuple[int, ...], set[str]]],
 ]:
     """Trace a forward pass to recover the leaf-module call graph.
 
@@ -244,6 +271,11 @@ def trace_module_graph(
             - edges (list): `(producer_node_id, consumer_node_id)` pairs, in call order.
             - input_ids (list): One synthetic node id per input tensor, in the same order as
                 `input_shapes`.
+            - final_output_records (list): One `(shape, producer_ids)` pair per tensor in the
+                model's own return value, in encounter order. A tensor whose `producer_ids` has
+                2+ entries is a merge the model returns directly, with no subsequent module call
+                to turn it into edges - the caller uses this to add a synthetic terminal node so
+                that merge isn't silently dropped from the graph.
     """
     dtypes = input_dtypes if input_dtypes is not None else (None,) * len(input_shapes)
     dummy_inputs = []
@@ -276,7 +308,8 @@ def trace_module_graph(
             for layer in model:
                 output = layer(output)
         else:
-            model(*dummy_inputs)
+            output = model(*dummy_inputs)
 
     input_ids = [f"{INPUT_NODE_ID}#{i}" for i in range(len(input_shapes))]
-    return id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids
+    final_output_records = _final_output_records(output)
+    return id_to_module, id_to_output_shape, id_to_extra_output_shapes, edges, input_ids, final_output_records


### PR DESCRIPTION
## Summary
- The tracer only records an edge when a tensor is passed into another leaf module call. A merge (e.g. `branch + shortcut`) that the model returns directly, with no subsequent module to receive it, was invisible to this - not just missing a "merge point" indicator, but silently dropping the shortcut branch's edge from the graph entirely.
- Found while checking whether LoRA adapters render correctly: a LoRA block's final merge (`base(x) + lora_B(lora_A(x))`) rendered as if it were a plain sequential chain, with no indication of the adapter branch at all.
- Adds a synthetic `Output` node (mirroring the existing synthetic `Input` node) that the final merge's producers connect into - only when the model's return value actually has 2+ producers. The ordinary single-producer case (the vast majority of models) is untouched.

## Test plan
- [x] New tests in `tests/test_regression_issues.py`: the core fix, a raw-input-as-shortcut edge case (`return self.fc(x) + x`), confirming no synthetic node is added when not needed, and rendering across all 3 styles
- [x] Full suite: 178/178 passing
- [x] Confirmed byte-for-byte identical rendering to `main` for existing models with merges (the `residual_model` fixtures, which all have a trailing layer after their merge - the already-working case)
- [x] `pre-commit run --all-files` clean, twice in a row