### PR TITLE
docs: demonstrate max_channels in lenet view

### DIFF
--- a/docs/examples/lenet_style/plot_max_channels_lenet_style.py
+++ b/docs/examples/lenet_style/plot_max_channels_lenet_style.py
@@ -1,0 +1,49 @@
+"""Maximum Channels
+=======================================
+
+Compare a compact channel stack with a taller one using ``max_channels``.
+Capping the number of rendered channel planes keeps wide convolutional layers
+legible without changing the model itself.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Conv2d(3, 128, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.Conv2d(128, 256, kernel_size=3, padding=1),
+    nn.AdaptiveAvgPool2d((1, 1)),
+)
+input_shape = (1, 3, 64, 64)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+
+# %%
+# Compact Channel Stack
+# ---------------------
+# Limiting the stack to 20 planes keeps wide layers compact.
+
+img_compact = visualtorch.render(model, input_shape=input_shape, style="lenet", max_channels=20)
+
+plt.figure(figsize=(img_compact.width / dpi, img_compact.height / dpi), dpi=dpi)
+plt.imshow(img_compact)
+plt.title("max_channels=20")
+plt.axis("off")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Default Channel Stack
+# ---------------------
+# The default cap of 100 preserves a taller channel stack.
+
+img_default = visualtorch.render(model, input_shape=input_shape, style="lenet")
+
+plt.figure(figsize=(img_default.width / dpi, img_default.height / dpi), dpi=dpi)
+plt.imshow(img_default)
+plt.title("max_channels=100 (default)")
+plt.axis("off")
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
## Summary

- add a dedicated `lenet_view` gallery example for the `max_channels` option
- render the same 128/256-channel CNN with `max_channels=20` and the default `100` side by side
- size the comparison from the rendered images so the legibility tradeoff remains visible

## Validation

- `python -m py_compile docs/examples/lenet_style/plot_max_channels_lenet_style.py`
- `ruff check docs/examples/lenet_style/plot_max_channels_lenet_style.py`
- `ruff format --check docs/examples/lenet_style/plot_max_channels_lenet_style.py`
- `git diff origin/main...HEAD --check`

I also attempted the example and targeted `tests/test_lenet_style.py` suite, but this runner does not have the project runtime dependencies installed (`matplotlib` for the example; `numpy`/`torch` for the tests), and its filesystem was too constrained for an honest full dependency installation. CI/Read the Docs should execute the gallery example with the documented dependencies.

Fixes #154
