### PR TITLE
Attribute ongoing copyright to VisualTorch Contributors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ MIT License
 
 Copyright (c) 2020 Paul Gavrikov
 
-Copyright (c) 2024 Willy Fitra Hendria
+Copyright (c) 2024 VisualTorch Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ mpl.rcParams["savefig.dpi"] = 300
 mpl.rcParams["figure.dpi"] = 300
 
 project = "VisualTorch"
-copyright = "2024, Willy Fitra Hendria"  # noqa: A001
+copyright = "2024, VisualTorch Contributors"  # noqa: A001
 release = "2024"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/markdown/license/index.md
+++ b/docs/source/markdown/license/index.md
@@ -6,7 +6,7 @@ Originally, this project was based on the [visualkeras](https://github.com/paulg
 
 --
 
-Copyright (c) 2024 Willy Fitra Hendria
+Copyright (c) 2024 VisualTorch Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/generate_banners.py
+++ b/scripts/generate_banners.py
@@ -9,7 +9,7 @@ Usage: `python scripts/generate_banners.py` from anywhere - writes directly to
 `docs/source/_static/images/banners/{readme-examples,visualizations-preview}.png`.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -11,7 +11,7 @@ Usage: `python scripts/generate_star_history.py` from anywhere - writes directly
 environment to avoid GitHub's low unauthenticated rate limit.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import json

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup file for visualtorch."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
     version="1.2.1",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
+    maintainer="VisualTorch Contributors",
     description="Architecture visualization of Torch models",
     keywords=["visualize architecture", "torch visualization", "visualtorch"],
     long_description=long_description,

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,6 +1,6 @@
 """Tests for the frontend-agnostic connector-routing helpers."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from visualtorch.connectors import _segment_intersects_rect, compute_skip_levels

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,6 +1,6 @@
 """Tests for flow view."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,6 @@
 """Tests for graph view."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -1,6 +1,6 @@
 """Tests for lenet view."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -3,7 +3,7 @@
 See https://github.com/willyfh/visualtorch/issues/63, /68, /69, /84, /85.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import pytest

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,6 +1,6 @@
 """Tests for the visualtorch.render() single entry point."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict

--- a/visualtorch/__init__.py
+++ b/visualtorch/__init__.py
@@ -1,6 +1,6 @@
 """Modules for pytorch model visualization."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import warnings

--- a/visualtorch/_volumetric_layout.py
+++ b/visualtorch/_volumetric_layout.py
@@ -9,7 +9,7 @@ vertical gap needed so one box's 3D extrusion doesn't visually occlude the box s
 offset flat rectangles).
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Callable

--- a/visualtorch/backend.py
+++ b/visualtorch/backend.py
@@ -4,7 +4,7 @@ Single entry point for extracting a model's structure - topology and shapes - vi
 adjacency graph mechanism (`visualtorch.utils.recorder`), for every rendering frontend to consume.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections import deque

--- a/visualtorch/connectors.py
+++ b/visualtorch/connectors.py
@@ -7,7 +7,7 @@ detour "level" via greedy interval-graph-coloring over their column spans, and d
 line, without any awareness of what a frontend's node objects actually look like.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Callable, Iterable

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -1,7 +1,7 @@
 """Flow View module for pytorch model visualization."""
 
 # Copyright (C) 2020 Paul Gavrikov
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import warnings

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -1,7 +1,7 @@
 """Graph View module for pytorch model visualization."""
 
 # Copyright (C) 2020 Paul Gavrikov
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict

--- a/visualtorch/layered.py
+++ b/visualtorch/layered.py
@@ -1,6 +1,6 @@
 """Deprecated pre-1.0 module path - `layered_view` now lives in `flow.py` as `flow_view`."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from .flow import layered_view

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -1,6 +1,6 @@
 """LeNet Style View module for pytorch model visualization."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import warnings

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -8,7 +8,7 @@ validated by constructing a per-style dataclass from them - a typo'd kwarg raise
 immediately, rather than being silently ignored.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Callable

--- a/visualtorch/utils/__init__.py
+++ b/visualtorch/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utils Modules for pytorch model visualization."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from .layer_utils import Input

--- a/visualtorch/utils/layer_utils.py
+++ b/visualtorch/utils/layer_utils.py
@@ -1,7 +1,7 @@
 """Layer Utils module for pytorch model visualization."""
 
 # Copyright (C) 2020 Paul Gavrikov
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 import warnings

--- a/visualtorch/utils/recorder.py
+++ b/visualtorch/utils/recorder.py
@@ -7,7 +7,7 @@ tensor-subclassing approach, stripped down to what every rendering style needs: 
 leaf module (a module with no children), not a node per tensor op.
 """
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Mapping

--- a/visualtorch/utils/traced_layer.py
+++ b/visualtorch/utils/traced_layer.py
@@ -1,6 +1,6 @@
 """Traced layer wrapper for graph-style pytorch model visualization."""
 
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from dataclasses import dataclass

--- a/visualtorch/utils/utils.py
+++ b/visualtorch/utils/utils.py
@@ -1,7 +1,7 @@
 """Utils module for pytorch model visualization."""
 
 # Copyright (C) 2020 Paul Gavrikov
-# Copyright (C) 2024 Willy Fitra Hendria
+# Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
 from typing import Any, TypeAlias


### PR DESCRIPTION
## Summary
- Changes the `2024 Willy Fitra Hendria` copyright line to `2024 VisualTorch Contributors` across `LICENSE.md`, the docs license page, `docs/source/conf.py`'s footer, and every per-file source header.
- Reflects that multiple people now hold real, merged code contributions to this project (e.g. connector styling, `type_ignore`, `outline_width`, `legend_position`, the funnel-connector fix), not just the original maintainer.
- The `2020 Paul Gavrikov` line (original visualkeras author) is left untouched everywhere it appears - this only changes the 2024 line.
- Left untouched intentionally: `setup.py`'s `author=` field (PyPI contact metadata, not a copyright statement) and the BibTeX/paper author bylines (a fixed, published academic record).

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest` passes (178/178, unaffected as expected for a copyright-text-only change)