### PR TITLE
Add Tariolle as a maintainer, CODEOWNER for visualtorch_mcp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @willyfh
+/visualtorch_mcp/ @Tariolle

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,5 @@
 
 * @willyfh
 /visualtorch_mcp/ @Tariolle
+/docs/source/markdown/get_started/mcp.md @Tariolle
+/tests/test_mcp.py @Tariolle

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,8 +20,7 @@ Current maintainer(s):
 
 - [@willyfh](https://github.com/willyfh)
 - [@Tariolle](https://github.com/Tariolle) (joined via the "brings in and takes ownership of a
-  substantial existing component" path above - contributed the `visualtorch_mcp` package, focus
-  area is the MCP integration)
+  substantial existing component" path above - contributed the `visualtorch_mcp` package)
 
 ## Decision-Making
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,6 +19,9 @@ how to actually submit a change, see [CONTRIBUTING.md](CONTRIBUTING.md).
 Current maintainer(s):
 
 - [@willyfh](https://github.com/willyfh)
+- [@Tariolle](https://github.com/Tariolle) (joined via the "brings in and takes ownership of a
+  substantial existing component" path above - contributed the `visualtorch_mcp` package, focus
+  area is the MCP integration)
 
 ## Decision-Making
 


### PR DESCRIPTION
## Summary
- Lists @Tariolle as a second maintainer in `GOVERNANCE.md`, via the existing "brings in and takes ownership of a substantial existing component" path - contributed the `visualtorch_mcp` package (#148).
- Adds a `CODEOWNERS` entry for `/visualtorch_mcp/` so MCP-specific PRs automatically route to him for review.

## Status

@Tariolle - heads up, this is queued up and ready for once you accept the Github invite.