### PR TITLE
Add optional graph connector arrowheads

### DIFF
--- a/docs/examples/graph/plot_show_arrows.py
+++ b/docs/examples/graph/plot_show_arrows.py
@@ -1,0 +1,46 @@
+"""Connector Arrowheads
+=======================================
+
+When a graph has skip connections (e.g. a residual block), plain connector lines can
+cross each other with no visual cue about data-flow direction. Setting
+``show_arrows=True`` draws a small arrowhead at each connector's downstream endpoint.
+
+The model here is a compact residual block: a main path through two hidden layers plus
+a skip connection from the stem output into the merge point before the final layer.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    """A dense residual block with a skip connection around fc1/fc2."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stem = nn.Linear(4, 4)
+        self.fc1 = nn.Linear(4, 4)
+        self.fc2 = nn.Linear(4, 4)
+        self.out = nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass with a skip connection around fc1/fc2."""
+        stem_out = self.stem(x)
+        branch = self.fc2(self.fc1(stem_out))
+        merged = branch + stem_out
+        return self.out(merged)
+
+
+model = ResidualBlock()
+input_shape = (1, 4)
+
+img = visualtorch.render(model, input_shape, style="graph", show_neurons=False, show_arrows=True, layer_spacing=80)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -476,3 +476,18 @@ def test_graph_view_type_ignore_reduces_diagram(batchnorm_model: nn.Module) -> N
     img_default = graph_view(batchnorm_model, input_shape=(2, 3, 8, 8))
     img_ignored = graph_view(batchnorm_model, input_shape=(2, 3, 8, 8), type_ignore=[nn.ReLU, nn.BatchNorm2d])
     assert img_ignored.tobytes() != img_default.tobytes()
+
+
+def test_graph_view_show_arrows_default_matches_existing_output(residual_model: nn.Module) -> None:
+    """show_arrows=False should match the existing default rendering exactly."""
+    img_default = graph_view(residual_model, input_shape=(1, 4), show_neurons=True)
+    img_explicit_false = graph_view(residual_model, input_shape=(1, 4), show_neurons=True, show_arrows=False)
+    assert img_explicit_false.tobytes() == img_default.tobytes()
+
+
+def test_graph_view_show_arrows_changes_connector_pixels(residual_model: nn.Module) -> None:
+    """show_arrows=True should alter connector pixels without changing canvas size."""
+    img_default = graph_view(residual_model, input_shape=(1, 4), show_neurons=True)
+    img_arrows = graph_view(residual_model, input_shape=(1, 4), show_neurons=True, show_arrows=True)
+    assert img_arrows.size == img_default.size
+    assert img_arrows.tobytes() != img_default.tobytes()

--- a/visualtorch/connectors.py
+++ b/visualtorch/connectors.py
@@ -11,6 +11,7 @@ line, without any awareness of what a frontend's node objects actually look like
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Callable, Iterable
+from math import hypot
 
 import aggdraw
 
@@ -192,15 +193,47 @@ def draw_connector(
     color: str | tuple[int, ...],
     width: int,
     detour_y: float | None = None,
+    show_arrows: bool = False,
 ) -> None:
     """Draw the line connector between two points.
 
     A plain straight line, unless `detour_y` is given - a skip connection whose column span
     would otherwise draw collinear with (and hidden under) the ordinary adjacent-column edges
-    beneath it, so it's routed with a right-angle detour instead.
+    beneath it, so it's routed with a right-angle detour instead. If `show_arrows` is True, a
+    small filled triangle is drawn at the downstream endpoint `(x2, y2)`.
     """
     pen = aggdraw.Pen(color, width)
+    # Arrow direction follows the final segment: straight line end-to-end, or vertical on detours.
     if detour_y is None:
         draw.line([x1, y1, x2, y2], pen)
+        dx = x2 - x1
+        dy = y2 - y1
+    else:
+        draw.line([x1, y1, x1, detour_y, x2, detour_y, x2, y2], pen)
+        dx = 0.0
+        dy = y2 - detour_y
+
+    if not show_arrows:
         return
-    draw.line([x1, y1, x1, detour_y, x2, detour_y, x2, y2], pen)
+
+    magnitude = hypot(dx, dy)
+    if magnitude == 0:
+        return
+
+    ux = dx / magnitude
+    uy = dy / magnitude
+    arrow_length = max(6.0, width * 4.0)
+    arrow_half_width = max(3.0, width * 2.0)
+
+    base_x = x2 - ux * arrow_length
+    base_y = y2 - uy * arrow_length
+    perp_x = -uy
+    perp_y = ux
+
+    left_x = base_x + perp_x * arrow_half_width
+    left_y = base_y + perp_y * arrow_half_width
+    right_x = base_x - perp_x * arrow_half_width
+    right_y = base_y - perp_y * arrow_half_width
+
+    brush = aggdraw.Brush(color)
+    draw.polygon([x2, y2, left_x, left_y, right_x, right_y], pen, brush)

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -44,7 +44,6 @@ def graph_view(
     outline_width: int = 1,
     connector_fill: str | tuple[int, ...] = "gray",
     connector_width: int = 1,
-    show_arrows: bool = False,
     ellipsize_after: int = 10,
     show_neurons: bool = True,
     opacity: int = 255,
@@ -53,6 +52,7 @@ def graph_view(
     font_color: str | tuple[int, ...] = "black",
     level_gap: int | None = None,
     show_input: bool = True,
+    show_arrows: bool = False,
 ) -> Image.Image:
     """Generates an architecture visualization for a given linear PyTorch model in a graph style.
 

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -43,6 +43,7 @@ def graph_view(
     type_ignore: list | None = None,
     connector_fill: str | tuple[int, ...] = "gray",
     connector_width: int = 1,
+    show_arrows: bool = False,
     ellipsize_after: int = 10,
     show_neurons: bool = True,
     opacity: int = 255,
@@ -82,6 +83,8 @@ def graph_view(
         type_ignore (list, optional): List of layer types in the torch model to ignore during drawing.
         connector_fill (Any, optional): Color for the connectors. Can be str or (R,G,B,A).
         connector_width (int, optional): Line-width of the connectors in pixels.
+        show_arrows (bool, optional): If True, draw a small arrowhead at each connector's
+            downstream endpoint to indicate data-flow direction.
         ellipsize_after (int, optional): Maximum number of neurons per layer to draw. If a layer is exceeding this,
             the remaining neurons will be drawn as ellipses.
         show_neurons (bool, optional): If True a node for each neuron in supported layers is created (constrained by
@@ -206,6 +209,7 @@ def graph_view(
         resolved_level_gap,
         connector_fill,
         connector_width,
+        show_arrows,
     )
 
     for layer in layers:
@@ -261,6 +265,7 @@ def _draw_connectors(
     resolved_level_gap: int,
     connector_fill: str | tuple[int, ...],
     connector_width: int,
+    show_arrows: bool,
 ) -> None:
     """Draw every connector, routing skip-connection edges above the diagram."""
     for start_id, end_id in edges:
@@ -286,6 +291,7 @@ def _draw_connectors(
                     color=connector_fill,
                     width=connector_width,
                     detour_y=detour_y,
+                    show_arrows=show_arrows,
                 )
             continue
 
@@ -301,6 +307,7 @@ def _draw_connectors(
                         color=connector_fill,
                         width=connector_width,
                         detour_y=detour_y,
+                        show_arrows=show_arrows,
                     )
 
 

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -53,11 +53,11 @@ class GraphStyleOptions:
     outline_width: int = 1
     connector_fill: str | tuple[int, ...] = "gray"
     connector_width: int = 1
-    show_arrows: bool = False
     ellipsize_after: int = 10
     show_neurons: bool = True
     show_dimension: bool = False
     show_input: bool = True
+    show_arrows: bool = False
 
 
 @dataclass

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -52,6 +52,7 @@ class GraphStyleOptions:
     type_ignore: list[type] | None = None
     connector_fill: str | tuple[int, ...] = "gray"
     connector_width: int = 1
+    show_arrows: bool = False
     ellipsize_after: int = 10
     show_neurons: bool = True
     show_dimension: bool = False
@@ -127,6 +128,7 @@ def _render_graph(
         node_spacing=options.node_spacing,
         connector_fill=options.connector_fill,
         connector_width=options.connector_width,
+        show_arrows=options.show_arrows,
         ellipsize_after=options.ellipsize_after,
         show_neurons=options.show_neurons,
         opacity=common.opacity,


### PR DESCRIPTION
## Summary

Closes #136.

Adds optional connector arrowheads for graph-style diagrams via `show_arrows: bool = False`.

When enabled, each connector draws a small filled triangle at its downstream endpoint `(x2, y2)`, oriented along the final segment:
- plain connectors: direction is `(x2 - x1, y2 - y1)`
- routed skip connectors: final segment is vertical, so direction is `(0, y2 - detour_y)`

Default behavior is unchanged (`show_arrows=False`), so existing graph output remains byte-identical unless the option is explicitly enabled.

## Changes

- **`visualtorch/connectors.py`**
  - Extend `draw_connector()` with optional arrowhead rendering at the downstream endpoint.
- **`visualtorch/graph.py`**
  - Add `show_arrows` to `graph_view()` and thread it through `_draw_connectors()`.
- **`visualtorch/render.py`**
  - Add `show_arrows` to `GraphStyleOptions` and forward it in `_render_graph()`.
- **`tests/test_graph.py`**
  - Assert `show_arrows=False` matches default output exactly.
  - Assert `show_arrows=True` changes pixels without changing canvas size (using `residual_model` to cover regular + routed skip edges).
- **`docs/examples/graph/plot_show_arrows.py`**
  - New gallery example demonstrating `show_arrows=True` on a compact residual block.

## Backward compatibility

- `show_arrows` defaults to `False`.
- Scope is graph style only (`graph_view` / `render(..., style="graph")`).
- Flow/lenet styles are unchanged.

## Test plan

- [x] `uv run pytest tests/test_graph.py::test_graph_view_show_arrows_default_matches_existing_output -v`
- [x] `uv run pytest tests/test_graph.py::test_graph_view_show_arrows_changes_connector_pixels -v`
- [x] `uv run pytest tests/test_graph.py -v`
- [x] `uv run python docs/examples/graph/plot_show_arrows.py`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest tests/`

## Notes

While testing skip-connection diagrams, I noticed routed arrowheads can be partially obscured when destination nodes are drawn after connectors. I posted screenshots and asked for preferred rendering behavior in #136 (overlay pass vs current draw order). Happy to adjust in a follow-up commit based on maintainer preference.