### PR TITLE
Mention pull requests as a valid maintainer-nomination venue

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,7 +47,7 @@ in a tool they've already built and maintained elsewhere) can also become a main
 without the sustained-PR history above. The trust signal there is the track record of the
 existing work, not incremental PRs to this repo.
 
-An existing maintainer nominates the candidate (e.g. in an issue or discussion), and current
+An existing maintainer nominates the candidate (e.g. in an issue, discussion, or pull request), and current
 maintainers approve by consensus. New maintainers are added to this document and given write
 access to the repository.
 


### PR DESCRIPTION
## Summary
- `GOVERNANCE.md`'s "Becoming a Maintainer" section only mentioned "an issue or discussion" as where a nomination could happen. A PR thread is just as natural a place - arguably more so, since that's literally where contribution quality gets demonstrated.

## Test plan
- [x] `pre-commit run --files GOVERNANCE.md` passes