### PR TITLE
Switch maintainer nomination to lazy consensus

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -50,7 +50,10 @@ existing work, not incremental PRs to this repo.
 An existing maintainer nominates the candidate (e.g. in an issue, discussion, or pull request).
 Any existing maintainer may approve the nomination - this doesn't require active sign-off from
 every maintainer, just visibility so others can raise concerns if they have any. New maintainers
-are added to this document and given write access to the repository.
+are added to this document and are typically given write access to the repository right away.
+
+Any maintainer who objects can still reverse the promotion within 14 days of it being announced,
+as long as they give a clear reason. Past that window, the promotion stands.
 
 ## Stepping Down / Inactivity
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,9 +47,10 @@ in a tool they've already built and maintained elsewhere) can also become a main
 without the sustained-PR history above. The trust signal there is the track record of the
 existing work, not incremental PRs to this repo.
 
-An existing maintainer nominates the candidate (e.g. in an issue, discussion, or pull request), and current
-maintainers approve by consensus. New maintainers are added to this document and given write
-access to the repository.
+An existing maintainer nominates the candidate (e.g. in an issue, discussion, or pull request).
+Any existing maintainer may approve the nomination - this doesn't require active sign-off from
+every maintainer, just visibility so others can raise concerns if they have any. New maintainers
+are added to this document and given write access to the repository.
 
 ## Stepping Down / Inactivity
 


### PR DESCRIPTION
## Summary
- "Current maintainers approve by consensus" (plural) would require every maintainer to actively sign off before adding a new one - real friction once there's more than one maintainer.
- Any existing maintainer can now approve a nomination unilaterally, as long as it happens visibly (in an issue, discussion, or PR) so others can object if they disagree.
- Deliberately symmetric, not founder-only: the point of having a second maintainer is bus-factor resilience if the founder becomes unavailable, so reserving this power to the founder alone would undermine that. Also consistent with the existing Stepping Down/Inactivity section, where remaining maintainers can already remove one unilaterally.
- Added a 14-day objection window: promotion isn't blocked on waiting, but any maintainer can still reverse it within that window if they have a clear reason.

## Test plan
- [x] `pre-commit run --files GOVERNANCE.md` passes