### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/docs/source/snippets/install/pypi.txt
+++ b/docs/source/snippets/install/pypi.txt
@@ -1,1 +1,1 @@
-pip install visualtorch==1.2.1
+pip install visualtorch==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="1.2.1",
+    version="1.3.0",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     maintainer="VisualTorch Contributors",


### PR DESCRIPTION
## Summary
- Bumps version from 1.2.1 to 1.3.0 (minor, since this covers new features - MCP integration, `outline_width`, `connector_fill`/`connector_width`, `type_ignore`, configurable flow legend position, integer/bool `input_dtype` support - plus a real bug fix, with nothing breaking) ahead of a new release.

## Test plan
- [x] `pre-commit run --files setup.py docs/source/snippets/install/pypi.txt`