### PR TITLE
docs: simplify docs homepage title

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,4 +1,4 @@
-# VisualTorch Documentation
+# VisualTorch
 
 VisualTorch aims to help visualize Torch-based neural network architectures. It currently supports generating flow-style, graph-style, and LeNet-style architectures for PyTorch Sequential and Custom models.
 


### PR DESCRIPTION
## Summary
- Changes the docs homepage's H1 from "VisualTorch Documentation" to just "VisualTorch" (`docs/source/index.md`).

## Test plan
- [x] `pre-commit run --files docs/source/index.md`