### PR TITLE
feat: deprecate graph_view/flow_view/lenet_view in favor of render()

### DIFF
--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -16,9 +16,13 @@ from PIL import Image, ImageSequence
 from torch import nn
 from visualtorch import animate
 from visualtorch.backend import extract_architecture
-from visualtorch.flow import flow_view
-from visualtorch.graph import graph_view
-from visualtorch.lenet_style import lenet_view
+
+# graph_view/flow_view/lenet_view are deprecated in favor of render() - importing the private
+# implementations directly (used here only to compare animate()'s last frame against the static
+# render for byte-identical output) so this doesn't spam a DeprecationWarning on every call.
+from visualtorch.flow import _flow_view as flow_view
+from visualtorch.graph import _graph_view as graph_view
+from visualtorch.lenet_style import _lenet_view as lenet_view
 
 _STATIC_VIEW_FUNCS: dict[str, Callable] = {
     "graph": graph_view,

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -11,7 +11,13 @@ import torch
 import torch.nn.functional as func
 from PIL import Image
 from torch import nn
-from visualtorch.flow import flow_view, layered_view
+
+# flow_view is deprecated in favor of render() - importing the private implementation directly
+# (aliased back to flow_view) so this file's tests, which exercise the actual rendering logic
+# rather than the deprecation wrapper itself, don't spam a DeprecationWarning on every call.
+from visualtorch.flow import _flow_view as flow_view
+from visualtorch.flow import flow_view as deprecated_flow_view
+from visualtorch.flow import layered_view
 
 
 @pytest.fixture()
@@ -659,6 +665,14 @@ def test_flow_view_2d_shape_seq_len_is_discarded() -> None:
     img_bigger_hidden = flow_view(model_bigger_hidden, input_shape=(1, 5, 8))
 
     assert img_short_seq.tobytes() != img_bigger_hidden.tobytes()
+
+
+def test_flow_view_is_deprecated(sequential_model: nn.Sequential) -> None:
+    """The deprecated public flow_view should still work, warn, and match render()'s output."""
+    with pytest.warns(DeprecationWarning, match="flow_view"):
+        deprecated_img = deprecated_flow_view(sequential_model, input_shape=(1, 3, 224, 224))
+    current_img = flow_view(sequential_model, input_shape=(1, 3, 224, 224))
+    assert deprecated_img.tobytes() == current_img.tobytes()
 
 
 def test_layered_view_still_works(sequential_model: nn.Sequential) -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,7 +10,12 @@ import torch
 from PIL import Image
 from torch import nn
 from visualtorch.backend import extract_architecture
-from visualtorch.graph import graph_view
+
+# graph_view is deprecated in favor of render() - importing the private implementation directly
+# so this file's tests (which exercise the actual rendering logic, not the deprecation wrapper
+# itself) don't spam a DeprecationWarning on every call.
+from visualtorch.graph import _graph_view as graph_view
+from visualtorch.graph import graph_view as deprecated_graph_view
 
 
 @pytest.fixture()
@@ -498,3 +503,11 @@ def test_graph_view_outline_width_accepted(conv_model: nn.Module) -> None:
     img_default = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False)
     img_thick = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False, outline_width=5)
     assert img_thick.tobytes() != img_default.tobytes()
+
+
+def test_graph_view_is_deprecated(dense_model: nn.Module) -> None:
+    """The deprecated public graph_view should still work, warn, and match render()'s output."""
+    with pytest.warns(DeprecationWarning, match="graph_view"):
+        deprecated_img = deprecated_graph_view(dense_model, input_shape=(1, 4))
+    current_img = graph_view(dense_model, input_shape=(1, 4))
+    assert deprecated_img.tobytes() == current_img.tobytes()

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -11,7 +11,12 @@ import torch
 import torch.nn.functional as func
 from PIL import Image
 from torch import nn
-from visualtorch.lenet_style import lenet_view
+
+# lenet_view is deprecated in favor of render() - importing the private implementation directly
+# so this file's tests (which exercise the actual rendering logic, not the deprecation wrapper
+# itself) don't spam a DeprecationWarning on every call.
+from visualtorch.lenet_style import _lenet_view as lenet_view
+from visualtorch.lenet_style import lenet_view as deprecated_lenet_view
 
 
 @pytest.fixture()
@@ -141,6 +146,14 @@ def classifier_model() -> nn.Module:
             return self.fc(x)
 
     return ClassifierModel()
+
+
+def test_lenet_view_is_deprecated(sequential_model: nn.Sequential) -> None:
+    """The deprecated public lenet_view should still work, warn, and match render()'s output."""
+    with pytest.warns(DeprecationWarning, match="lenet_view"):
+        deprecated_img = deprecated_lenet_view(sequential_model, input_shape=(1, 3, 224, 224))
+    current_img = lenet_view(sequential_model, input_shape=(1, 3, 224, 224))
+    assert deprecated_img.tobytes() == current_img.tobytes()
 
 
 def test_sequential_model_lenet_view_runs(sequential_model: nn.Sequential) -> None:

--- a/tests/test_regression_issues.py
+++ b/tests/test_regression_issues.py
@@ -10,9 +10,13 @@ import pytest
 import torch
 from torch import nn
 from visualtorch.backend import extract_architecture
-from visualtorch.flow import flow_view
-from visualtorch.graph import graph_view
-from visualtorch.lenet_style import lenet_view
+
+# graph_view/flow_view/lenet_view are deprecated in favor of render() - importing the private
+# implementations directly so this file's tests, which exercise the actual rendering logic rather
+# than the deprecation wrapper itself, don't spam a DeprecationWarning on every call.
+from visualtorch.flow import _flow_view as flow_view
+from visualtorch.graph import _graph_view as graph_view
+from visualtorch.lenet_style import _lenet_view as lenet_view
 from visualtorch.utils.utils import format_shape_label, self_multiply
 
 

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -81,6 +81,91 @@ def flow_view(
 ) -> PIL.Image:
     """Generate a flow-style architecture visualization for a given torch model.
 
+    Deprecated:
+        Since version 1.4.0. Use `visualtorch.render(model, input_shape, style="flow", ...)`
+        instead - every parameter here is forwarded unchanged.
+    """
+    warnings.warn(
+        "`flow_view` is deprecated and will be removed in a future release, use "
+        '`visualtorch.render(model, input_shape, style="flow", ...)` instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _flow_view(
+        model,
+        input_shape,
+        input_dtype,
+        to_file,
+        min_z,
+        min_xy,
+        max_z,
+        max_xy,
+        scale_z,
+        scale_xy,
+        type_ignore,
+        color_map,
+        palette,
+        low_dim_orientation,
+        background_fill,
+        draw_volume,
+        padding,
+        spacing,
+        draw_funnel,
+        shade_step,
+        legend,
+        font,
+        font_color,
+        opacity,
+        show_dimension,
+        level_gap,
+        show_input,
+        outline_width,
+        connector_fill,
+        connector_width,
+        one_dim_orientation,
+        legend_position,
+    )
+
+
+def _flow_view(
+    model: nn.Module | nn.Sequential | nn.ModuleList,
+    input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
+    to_file: str | None = None,
+    min_z: int = 10,
+    min_xy: int = 10,
+    max_z: int = 400,
+    max_xy: int = 2000,
+    scale_z: float = 0.1,
+    scale_xy: float = 1,
+    type_ignore: list | None = None,
+    color_map: dict | None = None,
+    palette: str = "okabe_ito",
+    low_dim_orientation: str = "z",
+    background_fill: str | tuple[int, ...] = "white",
+    draw_volume: bool = True,
+    padding: int = 10,
+    spacing: int = 10,
+    draw_funnel: bool = True,
+    shade_step: int = 10,
+    legend: bool = False,
+    font: ImageFont = None,
+    font_color: str | tuple[int, ...] = "black",
+    opacity: int = 255,
+    show_dimension: bool = False,
+    level_gap: int | None = None,
+    show_input: bool = True,
+    outline_width: int = 1,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
+    one_dim_orientation: str | None = None,
+    legend_position: LegendPosition = "bottom-left",
+) -> PIL.Image:
+    """The actual flow_view implementation.
+
+    Called directly by render() and layered_view() to avoid triggering flow_view's own
+    deprecation warning on every call.
+
     Args:
         model (torch.nn.Module): A torch model that will be visualized.
         input_shape (tuple): The shape of the input tensor (default: (1, 3, 224, 224)). For a
@@ -1038,4 +1123,7 @@ def layered_view(*args: object, **kwargs: object) -> PIL.Image:
     kwargs.pop("index_ignore", None)
     if "one_dim_orientation" in kwargs:
         kwargs["low_dim_orientation"] = kwargs.pop("one_dim_orientation")
-    return flow_view(*args, **kwargs)  # type: ignore[arg-type]
+    # Calls _flow_view directly (not flow_view) - flow_view is itself now deprecated too,
+    # and layered_view already emits its own warning above, so delegating to flow_view would
+    # spuriously double it.
+    return _flow_view(*args, **kwargs)  # type: ignore[arg-type]

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2024 VisualTorch Contributors
 # SPDX-License-Identifier: MIT
 
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from math import ceil
@@ -57,6 +58,75 @@ def graph_view(
     show_arrows: bool = False,
 ) -> Image.Image:
     """Generates an architecture visualization for a given linear PyTorch model in a graph style.
+
+    Deprecated:
+        Since version 1.4.0. Use `visualtorch.render(model, input_shape, style="graph", ...)`
+        instead - every parameter here is forwarded unchanged.
+    """
+    warnings.warn(
+        "`graph_view` is deprecated and will be removed in a future release, use "
+        '`visualtorch.render(model, input_shape, style="graph", ...)` instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _graph_view(
+        model,
+        input_shape,
+        input_dtype,
+        to_file,
+        color_map,
+        palette,
+        node_size,
+        background_fill,
+        padding,
+        layer_spacing,
+        node_spacing,
+        type_ignore,
+        outline_width,
+        connector_fill,
+        connector_width,
+        ellipsize_after,
+        show_neurons,
+        opacity,
+        show_dimension,
+        font,
+        font_color,
+        level_gap,
+        show_input,
+        show_arrows,
+    )
+
+
+def _graph_view(
+    model: torch.nn.Module,
+    input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
+    to_file: str | None = None,
+    color_map: dict[Any, Any] | None = None,
+    palette: str = "okabe_ito",
+    node_size: int = 50,
+    background_fill: str | tuple[int, ...] = "white",
+    padding: int = 10,
+    layer_spacing: int = 250,
+    node_spacing: int = 10,
+    type_ignore: list | None = None,
+    outline_width: int = 1,
+    connector_fill: str | tuple[int, ...] = "gray",
+    connector_width: int = 1,
+    ellipsize_after: int = 10,
+    show_neurons: bool = True,
+    opacity: int = 255,
+    show_dimension: bool = False,
+    font: ImageFont = None,
+    font_color: str | tuple[int, ...] = "black",
+    level_gap: int | None = None,
+    show_input: bool = True,
+    show_arrows: bool = False,
+) -> Image.Image:
+    """The actual graph_view implementation.
+
+    Called directly by render() to avoid triggering graph_view's own deprecation warning on
+    every render() call.
 
     Args:
         model (torch.nn.Module): A PyTorch model that will be visualized.

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -69,6 +69,87 @@ def lenet_view(
 ) -> PIL.Image:
     """Generate a LeNet style architecture visualization for a given torch model.
 
+    Deprecated:
+        Since version 1.4.0. Use `visualtorch.render(model, input_shape, style="lenet", ...)`
+        instead - every parameter here is forwarded unchanged.
+    """
+    warnings.warn(
+        "`lenet_view` is deprecated and will be removed in a future release, use "
+        '`visualtorch.render(model, input_shape, style="lenet", ...)` instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _lenet_view(
+        model,
+        input_shape,
+        input_dtype,
+        to_file,
+        min_z,
+        min_xy,
+        max_xy,
+        scale_z,
+        scale_xy,
+        type_ignore,
+        color_map,
+        palette,
+        low_dim_orientation,
+        background_fill,
+        padding,
+        spacing,
+        draw_funnel,
+        shade_step,
+        font,
+        font_color,
+        opacity,
+        max_channels,
+        offset_z,
+        level_gap,
+        show_dimension,
+        show_input,
+        outline_width,
+        connector_fill,
+        connector_width,
+        one_dim_orientation,
+    )
+
+
+def _lenet_view(
+    model: nn.Module | nn.Sequential | nn.ModuleList,
+    input_shape: InputShape,
+    input_dtype: InputDtype | None = None,
+    to_file: str | None = None,
+    min_z: int = 1,
+    min_xy: int = 10,
+    max_xy: int = 2000,
+    scale_z: float = 1,
+    scale_xy: float = 1,
+    type_ignore: list | None = None,
+    color_map: dict | None = None,
+    palette: str = "okabe_ito",
+    low_dim_orientation: str = "z",
+    background_fill: str | tuple[int, ...] = "white",
+    padding: int = 10,
+    spacing: int = 10,
+    draw_funnel: bool = True,
+    shade_step: int = 10,
+    font: ImageFont = None,
+    font_color: str | tuple[int, ...] = "black",
+    opacity: int = 255,
+    max_channels: int = 100,
+    offset_z: int = 10,
+    level_gap: int | None = None,
+    show_dimension: bool = True,
+    show_input: bool = True,
+    outline_width: int = 1,
+    connector_fill: str | tuple[int, ...] | None = None,
+    connector_width: int = 1,
+    one_dim_orientation: str | None = None,
+) -> PIL.Image:
+    """The actual lenet_view implementation.
+
+    Called directly by render() to avoid triggering lenet_view's own deprecation warning on
+    every render() call.
+
     TODO: remove unnecessary arguments for this LeNet style architecture.
 
     Args:

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -1,16 +1,21 @@
 """Single public entry point for pytorch model visualization.
 
-`graph_view`/`flow_view`/`lenet_view` (in `visualtorch.graph`/`.flow`/`.lenet_style`) render the
-same `extract_architecture`-derived structure three different ways; this module consolidates
+`_graph_view`/`_flow_view`/`_lenet_view` (in `visualtorch.graph`/`.flow`/`.lenet_style`) render
+the same `extract_architecture`-derived structure three different ways; this module consolidates
 them behind one function, `render(model, input_shape, style=..., **kwargs)`, so `style` picks
 the rendering style and every other parameter is style-appropriate keyword arguments. Kwargs are
 validated by constructing a per-style dataclass from them - a typo'd kwarg raises `TypeError`
 immediately, rather than being silently ignored.
 
+The old public names for these (`graph_view`/`flow_view`/`lenet_view`) are deprecated in favor
+of `render()` - `render()` calls the private implementations directly, not the deprecated public
+wrappers, so it never triggers their deprecation warning itself.
+
 `animate()` is the equivalent unified entry point for the animated GIF versions of each style.
 Unlike the static functions, the underlying per-style animate implementations are private
-(`_graph_view_animate`/etc.) - they never shipped in a public release, so `animate()` can be the
-one clean public entry point from the start, with no deprecation path ever needed for them.
+(`_graph_view_animate`/etc.) and always have been - they never shipped in a public release, so
+`animate()` was the one clean public entry point from the start, with no deprecation path ever
+needed for them.
 """
 
 # Copyright (C) 2024 VisualTorch Contributors
@@ -23,9 +28,9 @@ from typing import Any, Literal
 from PIL import Image
 from torch import nn
 
-from .flow import LegendPosition, _flow_view_animate, flow_view
-from .graph import _graph_view_animate, graph_view
-from .lenet_style import _lenet_view_animate, lenet_view
+from .flow import LegendPosition, _flow_view, _flow_view_animate
+from .graph import _graph_view, _graph_view_animate
+from .lenet_style import _lenet_view, _lenet_view_animate
 from .utils.utils import InputDtype, InputShape
 
 Style = Literal["graph", "flow", "lenet"]
@@ -121,7 +126,7 @@ def _render_graph(
     options: GraphStyleOptions,
     common: CommonOptions,
 ) -> Image.Image:
-    return graph_view(
+    return _graph_view(
         model,
         input_shape,
         input_dtype=common.input_dtype,
@@ -155,7 +160,7 @@ def _render_flow(
     options: FlowStyleOptions,
     common: CommonOptions,
 ) -> Image.Image:
-    return flow_view(
+    return _flow_view(
         model,
         input_shape,
         input_dtype=common.input_dtype,
@@ -197,7 +202,7 @@ def _render_lenet(
     options: LenetStyleOptions,
     common: CommonOptions,
 ) -> Image.Image:
-    return lenet_view(
+    return _lenet_view(
         model,
         input_shape,
         input_dtype=common.input_dtype,
@@ -295,8 +300,8 @@ def animate(
     """Generate an animated GIF revealing a PyTorch model's architecture one column at a time.
 
     This is the animated counterpart to `render()`: `style` picks which of the three styles to
-    animate, every other parameter matches that style's `graph_view()`/`flow_view()`/
-    `lenet_view()` (see their docstrings for the full per-style parameter list), plus 3 shared
+    animate, every other parameter matches that style's `GraphStyleOptions`/`FlowStyleOptions`/
+    `LenetStyleOptions`/`CommonOptions` fields (see `render()`'s docstring), plus 3 shared
     animation-only parameters: `frame_duration`, `final_hold_duration`, and `loop`. Unlike
     `render()`, kwargs aren't validated via a dataclass here - the underlying implementation
     functions already have explicit (not `**kwargs`) signatures, so an unrecognized keyword
@@ -311,8 +316,9 @@ def animate(
         style (str, optional): Which rendering style to use - `"graph"` (a node/edge diagram),
             `"flow"` (stacked volumetric/2D boxes connected by funnels), or `"lenet"` (the
             classic LeNet look).
-        **kwargs: Style-specific options, matching that style's `graph_view()`/`flow_view()`/
-            `lenet_view()` function, plus 3 shared animation-only options: `frame_duration`
+        **kwargs: Style-specific options (see `GraphStyleOptions`/`FlowStyleOptions`/
+            `LenetStyleOptions`/`CommonOptions` for the full per-style list), plus 3 shared
+            animation-only options: `frame_duration`
             (milliseconds each intermediate frame is displayed, default 600),
             `final_hold_duration` (milliseconds the final, fully-revealed frame is displayed
             before the GIF loops, default 1500), and `loop` (if True, the default, the GIF loops


### PR DESCRIPTION
## Summary
- `graph_view`, `flow_view`, and `lenet_view` are now deprecated (`DeprecationWarning`) in favor of `render(model, input_shape, style=..., **kwargs)`, which already wraps them internally.
- Each function's original implementation moved to a private counterpart (`_graph_view`/`_flow_view`/`_lenet_view`); the public name now warns and delegates. `render()` and `layered_view()` call the private implementations directly so they never trigger the new warning themselves.
- Every parameter and default is unchanged - this is a pure warn-and-delegate wrapper, not a behavior change.

Closes #170

## Test plan
- [x] `pytest tests/ -q` - 246 passed, 1 skipped, only pre-existing/unrelated Pillow warnings remain
- [x] New tests assert each deprecated function still works, warns, and produces byte-identical output to its replacement
- [x] `pre-commit run --files <changed>` clean, twice consecutively