### PR TITLE
docs: demonstrate level_gap for nested skip connections

### DIFF
--- a/docs/examples/flow/plot_level_gap_flow.py
+++ b/docs/examples/flow/plot_level_gap_flow.py
@@ -1,0 +1,63 @@
+"""Skip-Connection Level Spacing
+=======================================
+
+``level_gap`` controls the vertical distance in pixels between overlapping skip-connection routes. This
+nested residual model creates two detour levels: an inner shortcut around one convolution and an
+outer shortcut around the whole block. Compare a compact setting with a more widely spaced one.
+The additional rendering options separate the boxes and make the routed lines easier to see.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class NestedResidualBlock(nn.Module):
+    """A residual block with one shortcut nested inside another."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.inner_relu = nn.ReLU()
+        self.conv3 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.outer_relu = nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the block with overlapping inner and outer shortcuts."""
+        outer_identity = x
+        x = self.conv1(x)
+        inner_identity = x
+        x = self.inner_relu(self.conv2(x) + inner_identity)
+        x = self.conv3(x)
+        return self.outer_relu(x + outer_identity)
+
+
+model = NestedResidualBlock(channels=4)
+input_shape = (1, 4, 16, 16)
+
+level_gaps = (20, 80)
+images = [
+    visualtorch.render(
+        model,
+        input_shape,
+        style="flow",
+        level_gap=level_gap,
+        spacing=25,
+        connector_width=2,
+    )
+    for level_gap in level_gaps
+]
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+figure_width = min(12, max(8, sum(img.width for img in images) / dpi))
+figure_height = min(4, max(3, max(img.height for img in images) / dpi))
+_, axes = plt.subplots(1, 2, figsize=(figure_width, figure_height), dpi=dpi)
+for ax, img, level_gap in zip(axes, images, level_gaps, strict=True):
+    ax.imshow(img)
+    ax.set_title(f"level_gap={level_gap}")
+    ax.axis("off")
+
+plt.tight_layout()
+plt.show()

--- a/docs/examples/graph/plot_level_gap_graph.py
+++ b/docs/examples/graph/plot_level_gap_graph.py
@@ -1,0 +1,64 @@
+"""Skip-Connection Level Spacing
+=======================================
+
+``level_gap`` controls the vertical distance in pixels between overlapping skip-connection routes. This
+nested residual model creates two detour levels: an inner shortcut around one convolution and an
+outer shortcut around the whole block. Compare a compact setting with a more widely spaced one.
+The additional rendering options keep the routed lines prominent and the diagram compact.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class NestedResidualBlock(nn.Module):
+    """A residual block with one shortcut nested inside another."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.inner_relu = nn.ReLU()
+        self.conv3 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.outer_relu = nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the block with overlapping inner and outer shortcuts."""
+        outer_identity = x
+        x = self.conv1(x)
+        inner_identity = x
+        x = self.inner_relu(self.conv2(x) + inner_identity)
+        x = self.conv3(x)
+        return self.outer_relu(x + outer_identity)
+
+
+model = NestedResidualBlock(channels=4)
+input_shape = (1, 4, 16, 16)
+
+level_gaps = (20, 80)
+images = [
+    visualtorch.render(
+        model,
+        input_shape,
+        style="graph",
+        level_gap=level_gap,
+        layer_spacing=120,
+        show_neurons=False,
+        connector_width=2,
+    )
+    for level_gap in level_gaps
+]
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+figure_width = min(12, max(8, sum(img.width for img in images) / dpi))
+figure_height = min(4, max(3, max(img.height for img in images) / dpi))
+_, axes = plt.subplots(1, 2, figsize=(figure_width, figure_height), dpi=dpi)
+for ax, img, level_gap in zip(axes, images, level_gaps, strict=True):
+    ax.imshow(img)
+    ax.set_title(f"level_gap={level_gap}")
+    ax.axis("off")
+
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_level_gap_lenet_style.py
+++ b/docs/examples/lenet_style/plot_level_gap_lenet_style.py
@@ -1,0 +1,64 @@
+"""Skip-Connection Level Spacing
+=======================================
+
+``level_gap`` controls the vertical distance in pixels between overlapping skip-connection routes. This
+nested residual model creates two detour levels: an inner shortcut around one convolution and an
+outer shortcut around the whole block. Compare a compact setting with a more widely spaced one.
+The additional rendering options separate the boxes and keep attention on the routed lines.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import torch
+import visualtorch
+from torch import nn
+
+
+class NestedResidualBlock(nn.Module):
+    """A residual block with one shortcut nested inside another."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.inner_relu = nn.ReLU()
+        self.conv3 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.outer_relu = nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the block with overlapping inner and outer shortcuts."""
+        outer_identity = x
+        x = self.conv1(x)
+        inner_identity = x
+        x = self.inner_relu(self.conv2(x) + inner_identity)
+        x = self.conv3(x)
+        return self.outer_relu(x + outer_identity)
+
+
+model = NestedResidualBlock(channels=4)
+input_shape = (1, 4, 16, 16)
+
+level_gaps = (20, 80)
+images = [
+    visualtorch.render(
+        model,
+        input_shape,
+        style="lenet",
+        level_gap=level_gap,
+        spacing=25,
+        show_dimension=False,
+        connector_width=2,
+    )
+    for level_gap in level_gaps
+]
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+figure_width = min(12, max(8, sum(img.width for img in images) / dpi))
+figure_height = min(4, max(3, max(img.height for img in images) / dpi))
+_, axes = plt.subplots(1, 2, figsize=(figure_width, figure_height), dpi=dpi)
+for ax, img, level_gap in zip(axes, images, level_gaps, strict=True):
+    ax.imshow(img)
+    ax.set_title(f"level_gap={level_gap}")
+    ax.axis("off")
+
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
## Summary

This PR adds dedicated Sphinx-Gallery examples demonstrating how `level_gap` controls the vertical spacing between stacked skip-connection routes.

Examples are included for all three rendering styles:

- Graph
- Flow
- LeNet

Closes #153.

## Motivation

`level_gap` is supported by every rendering style, but previously had no dedicated examples. Its effect is only visible when multiple skip connections overlap and require separate routing levels, so a simple sequential or single-residual model would not demonstrate the option clearly.

These examples make the behavior discoverable and provide copyable reference implementations.

## Implementation

Each example defines a small nested residual block containing:

- an inner shortcut around one convolution
- an outer shortcut around the complete block

Because the shortcuts overlap, VisualTorch assigns them to two separate detour levels.

The model is rendered twice:

- `level_gap=20` for compact routing
- `level_gap=80` for more widely separated routing

Both results are displayed side by side to make the difference immediately visible.

## Added examples

- `docs/examples/graph/plot_level_gap_graph.py`
- `docs/examples/flow/plot_level_gap_flow.py`
- `docs/examples/lenet_style/plot_level_gap_lenet_style.py`

The examples use the unified `visualtorch.render()` API rather than the deprecated style-specific view functions.

Style-specific display options are limited to improving legibility:

- Graph hides individual neurons and uses compact layer spacing.
- Flow adds horizontal spacing between boxes.
- LeNet hides dimension labels to keep attention on the routes.
- Connector width is increased slightly across all styles.

Figure dimensions are derived from the rendered images with bounded minimum and maximum sizes. This keeps the comparison readable without producing unnecessarily oversized documentation assets.

## Validation

The following checks were completed locally:

- All three gallery example scripts executed successfully.
- Generated output for every style was visually inspected.
- Targeted pre-commit hooks passed, including:
  - Ruff linting
  - Ruff formatting
  - mypy
  - whitespace and file checks
- Full test suite:

  ```text
  246 passed, 1 skipped
  ```

The skipped test covers the optional MCP dependency, which was not installed in the development environment.

## Scope

This is a documentation-only change:

- no production behavior changed
- no public API changed
- no new dependencies added
- no existing examples modified