### PR TITLE
docs: demonstrate animation timing options

### DIFF
--- a/docs/examples/flow/plot_animated_reveal_flow.py
+++ b/docs/examples/flow/plot_animated_reveal_flow.py
@@ -47,4 +47,14 @@ input_shape = (1, 8, 16, 16)
 
 # Returns a list[Image.Image], one per column, in reveal order - pass to_file="your_path.gif" to
 # save it directly as an animated GIF instead.
-frames = visualtorch.animate(model, input_shape, style="flow", scale_xy=3)
+# frame_duration controls intermediate frames, final_hold_duration controls the completed frame,
+# and loop controls whether a saved GIF repeats.
+frames = visualtorch.animate(
+    model,
+    input_shape,
+    style="flow",
+    scale_xy=3,
+    frame_duration=500,
+    final_hold_duration=1500,
+    loop=True,
+)

--- a/docs/examples/graph/plot_animated_reveal_graph.py
+++ b/docs/examples/graph/plot_animated_reveal_graph.py
@@ -47,4 +47,15 @@ input_shape = (1, 8, 16, 16)
 
 # Returns a list[Image.Image], one per column, in reveal order - pass to_file="your_path.gif" to
 # save it directly as an animated GIF instead.
-frames = visualtorch.animate(model, input_shape, style="graph", show_neurons=False, layer_spacing=60)
+# frame_duration controls intermediate frames, final_hold_duration controls the completed frame,
+# and loop controls whether a saved GIF repeats.
+frames = visualtorch.animate(
+    model,
+    input_shape,
+    style="graph",
+    show_neurons=False,
+    layer_spacing=60,
+    frame_duration=500,
+    final_hold_duration=1500,
+    loop=True,
+)

--- a/docs/examples/lenet_style/plot_animated_reveal_lenet_style.py
+++ b/docs/examples/lenet_style/plot_animated_reveal_lenet_style.py
@@ -47,4 +47,14 @@ input_shape = (1, 8, 16, 16)
 
 # Returns a list[Image.Image], one per column, in reveal order - pass to_file="your_path.gif" to
 # save it directly as an animated GIF instead.
-frames = visualtorch.animate(model, input_shape, style="lenet", scale_xy=3)
+# frame_duration controls intermediate frames, final_hold_duration controls the completed frame,
+# and loop controls whether a saved GIF repeats.
+frames = visualtorch.animate(
+    model,
+    input_shape,
+    style="lenet",
+    scale_xy=3,
+    frame_duration=500,
+    final_hold_duration=1500,
+    loop=True,
+)


### PR DESCRIPTION
## Summary
- demonstrate `frame_duration` and `final_hold_duration` in all three animated reveal examples
- show that `loop=True` makes saved GIFs repeat
- keep the graph, flow, and LeNet-style examples aligned

Closes #172

## Verification
- relevant pre-commit hooks run individually: `mypy`, `ruff`, `ruff-format`, `trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`, `debug-statements`, and `detect-private-key`
- `.venv\Scripts\python.exe -m pytest tests\test_animation.py -q` (41 passed)
- ran each of the three updated example scripts successfully
- `.venv\Scripts\python.exe -m py_compile` on all three files
- `git diff --check`

The Prettier and markdownlint hooks do not match these Python example files.