### PR TITLE
Add legends to graph and LeNet views

### DIFF
--- a/docs/examples/graph/plot_legend_graph.py
+++ b/docs/examples/graph/plot_legend_graph.py
@@ -1,0 +1,32 @@
+"""Layer Legend
+=======================================
+
+Add a legend below a graph diagram with ``legend=True``. Each circular swatch
+uses the same color as its layer type in the diagram.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Linear(4, 6),
+    nn.ReLU(),
+    nn.Linear(6, 3),
+)
+input_shape = (1, 4)
+
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="graph",
+    show_neurons=True,
+    legend=True,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/lenet_style/plot_legend_lenet_style.py
+++ b/docs/examples/lenet_style/plot_legend_lenet_style.py
@@ -1,0 +1,33 @@
+"""Layer Legend
+=======================================
+
+Add a legend below a LeNet-style diagram with ``legend=True``. The legend uses
+stacked-plane swatches that match the colors and visual style of the layers.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+input_shape = (1, 3, 32, 32)
+
+img = visualtorch.render(
+    model,
+    input_shape=input_shape,
+    style="lenet",
+    legend=True,
+)
+
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+plt.imshow(img)
+plt.axis("off")
+plt.tight_layout()
+plt.show()

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -182,6 +182,27 @@ def test_flow_legend_fixed_and_correct_from_first_frame() -> None:
     assert legend_crop(frames[0]).tobytes() == legend_crop(frames[-1]).tobytes()
 
 
+@pytest.mark.parametrize("style", ["graph", "lenet"])
+def test_graph_and_lenet_legends_are_fixed_from_first_frame(style: str) -> None:
+    """Graph and LeNet animations should show the complete, fixed legend on every frame."""
+    model = nn.Sequential(nn.Conv2d(3, 4, 3, 1, 1), nn.BatchNorm2d(4), nn.ReLU())
+    input_shape = (1, 3, 8, 8)
+
+    no_legend_static = _STATIC_VIEW_FUNCS[style](model, input_shape, legend=False)
+    static_with_legend = _STATIC_VIEW_FUNCS[style](model, input_shape, legend=True)
+    frames = animate(model, input_shape, style=style, legend=True)
+
+    assert frames[-1].tobytes() == static_with_legend.tobytes()
+
+    legend_strip_height = static_with_legend.height - no_legend_static.height
+    assert legend_strip_height > 0
+
+    def legend_crop(img: Image.Image) -> Image.Image:
+        return img.crop((0, img.height - legend_strip_height, img.width, img.height))
+
+    assert legend_crop(frames[0]).tobytes() == legend_crop(frames[-1]).tobytes()
+
+
 @pytest.mark.parametrize("style", _STYLES)
 def test_show_dimension_labels_appear_with_their_column(style: str, sequential_model: nn.Module) -> None:
     """A column's shape label appears exactly when that column's boxes do, not before."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -429,6 +429,22 @@ def test_graph_view_residual_model_show_neurons_true_runs(residual_model: nn.Mod
     assert img is not None
 
 
+def test_graph_view_with_legend(conv_model: nn.Module) -> None:
+    """legend=True should append a circular layer-color legend."""
+    without_legend = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False)
+    with_legend = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False, legend=True)
+
+    assert with_legend.height > without_legend.height
+
+
+def test_graph_view_legend_false_preserves_default(conv_model: nn.Module) -> None:
+    """The opt-in legend must not change graph_view's default output."""
+    default = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False)
+    explicit_false = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False, legend=False)
+
+    assert explicit_false.tobytes() == default.tobytes()
+
+
 def test_graph_view_output_size_matches_pre_refactor_baseline(
     dense_model: nn.Module,
     conv_model: nn.Module,

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -225,6 +225,27 @@ def test_lenet_view_show_dimension_can_be_disabled(sequential_model: nn.Sequenti
     assert without_labels.height < with_labels.height
 
 
+def test_lenet_view_with_legend(small_sequential_model: nn.Sequential) -> None:
+    """legend=True should append a stacked-plane layer-color legend."""
+    without_legend = lenet_view(small_sequential_model, input_shape=(1, 3, 16, 16), show_dimension=False)
+    with_legend = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+    )
+
+    assert with_legend.height > without_legend.height
+
+
+def test_lenet_view_legend_false_preserves_default(small_sequential_model: nn.Sequential) -> None:
+    """The opt-in legend must not change lenet_view's default output."""
+    default = lenet_view(small_sequential_model, input_shape=(1, 3, 16, 16))
+    explicit_false = lenet_view(small_sequential_model, input_shape=(1, 3, 16, 16), legend=False)
+
+    assert explicit_false.tobytes() == default.tobytes()
+
+
 def test_lenet_view_writes_to_file(sequential_model: nn.Sequential, tmp_path: Path) -> None:
     """to_file should save a readable image to disk."""
     out_file = tmp_path / "lenet.png"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -99,7 +99,16 @@ def test_render_rejects_typo_d_common_kwarg(sequential_model: nn.Sequential) -> 
 def test_render_rejects_kwarg_from_a_different_style(sequential_model: nn.Sequential) -> None:
     """A kwarg valid for one style but not another should raise TypeError for the wrong style."""
     with pytest.raises(TypeError):
-        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", legend=True)
+        render(sequential_model, input_shape=(1, 3, 16, 16), style="graph", draw_volume=True)
+
+
+@pytest.mark.parametrize("style", ["graph", "lenet"])
+def test_render_forwards_legend_for_graph_and_lenet(sequential_model: nn.Sequential, style: str) -> None:
+    """Graph and LeNet styles should accept and forward legend through render()."""
+    without_legend = render(sequential_model, input_shape=(1, 3, 16, 16), style=style, legend=False)
+    with_legend = render(sequential_model, input_shape=(1, 3, 16, 16), style=style, legend=True)
+
+    assert with_legend.height > without_legend.height
 
 
 def test_render_forwards_flow_legend_position(sequential_model: nn.Sequential) -> None:

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -27,7 +27,9 @@ from .utils.utils import (
     InputDtype,
     InputShape,
     format_shape_label,
+    linear_layout,
     resolve_palette,
+    vertical_image_concat,
 )
 
 
@@ -56,6 +58,7 @@ def graph_view(
     level_gap: int | None = None,
     show_input: bool = True,
     show_arrows: bool = False,
+    legend: bool = False,
 ) -> Image.Image:
     """Generates an architecture visualization for a given linear PyTorch model in a graph style.
 
@@ -94,6 +97,7 @@ def graph_view(
         level_gap,
         show_input,
         show_arrows,
+        legend,
     )
 
 
@@ -122,6 +126,7 @@ def _graph_view(
     level_gap: int | None = None,
     show_input: bool = True,
     show_arrows: bool = False,
+    legend: bool = False,
 ) -> Image.Image:
     """The actual graph_view implementation.
 
@@ -176,6 +181,7 @@ def _graph_view(
             discard that edge.
         show_arrows (bool, optional): If True, draw a small arrowhead at each connector's
             downstream endpoint to indicate data-flow direction.
+        legend (bool, optional): If True, append a layer-color legend using circular swatches.
 
     Returns:
         Image.Image: Generated architecture image.
@@ -196,6 +202,7 @@ def _graph_view(
         show_neurons,
         opacity,
         show_dimension,
+        legend,
         font,
         level_gap,
         show_input,
@@ -212,6 +219,10 @@ def _graph_view(
         show_arrows=show_arrows,
         show_dimension=show_dimension,
         font_color=font_color,
+        legend=legend,
+        opacity=opacity,
+        spacing=node_spacing,
+        background_fill=background_fill,
     )
 
     if to_file is not None:
@@ -232,6 +243,8 @@ class _RenderSetup:
     edge_to_level: dict[tuple[str, str], int]
     num_levels: int
     resolved_level_gap: int
+    layer_types: list[type]
+    color_map: dict
     font: ImageFont
     img_template: Image.Image
 
@@ -252,6 +265,7 @@ def _prepare_render(
     show_neurons: bool,
     opacity: int,
     show_dimension: bool,
+    legend: bool,
     font: ImageFont,
     level_gap: int | None,
     show_input: bool,
@@ -292,6 +306,7 @@ def _prepare_render(
 
     current_x = padding  # + input_label_size[0] + text_padding
 
+    layer_types: list[type] = []
     layers, layer_y, id_to_node_list_map, label_info = _create_architecture(
         filtered_columns,
         current_x,
@@ -304,6 +319,7 @@ def _prepare_render(
         layer_spacing,
         ColorWheel(colors=resolve_palette(palette)),
         outline_width,
+        layer_types,
     )
 
     # An edge whose endpoint was just dropped above (a hidden input's own edges) can no longer
@@ -322,7 +338,7 @@ def _prepare_render(
     resolved_level_gap = level_gap if level_gap is not None else node_size
     top_margin_for_skips = num_levels * resolved_level_gap
 
-    if font is None and show_dimension:
+    if font is None and (show_dimension or legend):
         font = ImageFont.load_default()
 
     # Reserve a fixed-height strip below each layer's own content for its shape label,
@@ -364,6 +380,8 @@ def _prepare_render(
         edge_to_level=edge_to_level,
         num_levels=num_levels,
         resolved_level_gap=resolved_level_gap,
+        layer_types=layer_types,
+        color_map=_color_map,
         font=font,
         img_template=img_template,
     )
@@ -379,6 +397,10 @@ def _draw_architecture_frame(
     show_arrows: bool,
     show_dimension: bool,
     font_color: str | tuple[int, ...],
+    legend: bool,
+    opacity: int,
+    spacing: int,
+    background_fill: str | tuple[int, ...],
 ) -> Image.Image:
     """Draw a single frame: everything in columns `0..reveal_up_to`, on a copy of the shared canvas.
 
@@ -418,6 +440,19 @@ def _draw_architecture_frame(
     if show_dimension:
         img = _draw_dimension_labels(img, setup.label_info[: reveal_up_to + 1], setup.font, font_color)
 
+    if legend:
+        img = _draw_legend(
+            img,
+            setup.layer_types,
+            setup.color_map,
+            setup.font,
+            font_color,
+            opacity,
+            spacing,
+            padding,
+            background_fill,
+        )
+
     return img
 
 
@@ -446,6 +481,7 @@ def _graph_view_animate(
     level_gap: int | None = None,
     show_input: bool = True,
     show_arrows: bool = False,
+    legend: bool = False,
     frame_duration: int = 600,
     final_hold_duration: int = 1500,
     loop: bool = True,
@@ -503,6 +539,7 @@ def _graph_view_animate(
             discard that edge.
         show_arrows (bool, optional): If True, draw a small arrowhead at each connector's
             downstream endpoint to indicate data-flow direction.
+        legend (bool, optional): If True, append a fixed layer-color legend using circular swatches.
         frame_duration (int, optional): Milliseconds each intermediate frame is displayed.
         final_hold_duration (int, optional): Milliseconds the final, fully-revealed frame is
             displayed before the GIF loops - gives a viewer time to actually see the complete
@@ -536,6 +573,7 @@ def _graph_view_animate(
         show_neurons,
         opacity,
         show_dimension,
+        legend,
         font,
         level_gap,
         show_input,
@@ -553,6 +591,10 @@ def _graph_view_animate(
             show_arrows,
             show_dimension,
             font_color,
+            legend,
+            opacity,
+            node_spacing,
+            background_fill,
         )
 
     return animate_frames(
@@ -701,6 +743,57 @@ def _draw_dimension_labels(
     return Image.alpha_composite(img, text_img)
 
 
+def _draw_legend(
+    img: Image.Image,
+    layer_types: list[type],
+    color_map: dict,
+    font: ImageFont,
+    font_color: str | tuple[int, ...],
+    opacity: int,
+    spacing: int,
+    padding: int,
+    background_fill: str | tuple[int, ...],
+) -> Image.Image:
+    """Append a color legend whose swatches match graph nodes."""
+    text_height = font.getbbox("Ag")[3]
+    swatch_size = text_height
+    patches = []
+
+    for layer_type in layer_types:
+        label = layer_type.__name__
+        text_width = font.getbbox(label)[2]
+        patch_size = (swatch_size + spacing + text_width, swatch_size)
+        patch = Image.new("RGBA", patch_size, background_fill)
+        text_layer = Image.new("RGBA", patch_size, (0, 0, 0, 0))
+        shape_draw = aggdraw.Draw(patch)
+        text_draw = ImageDraw.Draw(text_layer)
+
+        swatch = Circle()
+        swatch.x2 = swatch_size
+        swatch.y2 = swatch_size
+        swatch.set_fill(color_map[layer_type]["fill"], opacity)
+        swatch.outline = color_map[layer_type]["outline"]
+        swatch.draw(shape_draw)
+
+        text_y = (patch_size[1] - text_height) / 2
+        text_draw.text((swatch_size + spacing, text_y), label, font=font, fill=font_color)
+
+        shape_draw.flush()
+        patch.paste(text_layer, mask=text_layer)
+        patches.append(patch)
+
+    legend_image = linear_layout(
+        patches,
+        max_width=img.width,
+        max_height=img.height,
+        padding=padding,
+        spacing=spacing,
+        background_fill=background_fill,
+        horizontal=True,
+    )
+    return vertical_image_concat(img, legend_image, background_fill)
+
+
 def _retrieve_isbox_units(layer: TracedLayer, show_neurons: bool) -> tuple[bool, int]:
     """Return the number of units and the flag whether to visualize using a box or not.
 
@@ -734,7 +827,8 @@ def _create_architecture(
     opacity: int,
     layer_spacing: int,
     color_wheel: ColorWheel,
-    outline_width: int = 1,
+    outline_width: int,
+    layer_types: list[type],
 ) -> tuple[list, list, dict, list[list[tuple[str, float, float]]]]:
     """Create nodes of architecture for each layers."""
     id_to_node_list_map = {}
@@ -782,6 +876,14 @@ def _create_architecture(
                 c.outline_width = outline_width
 
                 layer_nodes.append(c)
+
+            if layer_nodes:
+                if layer_type not in layer_types:
+                    layer_types.append(layer_type)
+                color_map[layer_type] = {
+                    "fill": layer_nodes[0].fill,
+                    "outline": layer_nodes[0].outline,
+                }
 
             id_to_node_list_map[layer.node_id] = layer_nodes
             nodes.extend(layer_nodes)

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -28,8 +28,10 @@ from .utils.utils import (
     StackedBox,
     format_shape_label,
     get_rgba_tuple,
+    linear_layout,
     resolve_palette,
     self_multiply,
+    vertical_image_concat,
 )
 
 _LABEL_ROW_HEIGHT = 100
@@ -66,6 +68,7 @@ def lenet_view(
     connector_fill: str | tuple[int, ...] | None = None,
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
+    legend: bool = False,
 ) -> PIL.Image:
     """Generate a LeNet style architecture visualization for a given torch model.
 
@@ -110,6 +113,7 @@ def lenet_view(
         connector_fill,
         connector_width,
         one_dim_orientation,
+        legend,
     )
 
 
@@ -144,6 +148,7 @@ def _lenet_view(
     connector_fill: str | tuple[int, ...] | None = None,
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
+    legend: bool = False,
 ) -> PIL.Image:
     """The actual lenet_view implementation.
 
@@ -209,6 +214,7 @@ def _lenet_view(
             or a tuple (R, G, B, A). If None, inherits the target box's outline color.
         connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
+        legend (bool, optional): If True, append a layer-color legend using stacked-plane swatches.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
@@ -250,6 +256,11 @@ def _lenet_view(
         padding=padding,
         show_dimension=show_dimension,
         font_color=font_color,
+        legend=legend,
+        shade_step=shade_step,
+        opacity=opacity,
+        spacing=spacing,
+        background_fill=background_fill,
     )
 
     if to_file is not None:
@@ -267,6 +278,8 @@ class _LenetRenderSetup:
     edge_to_level: dict[tuple[str, str], int]
     num_levels: int
     resolved_level_gap: int
+    layer_types: list[type]
+    color_map: dict
     font: ImageFont
     diagram_height: float
     img_template: Image.Image
@@ -403,6 +416,8 @@ def _prepare_lenet_render(
         edge_to_level=edge_to_level,
         num_levels=num_levels,
         resolved_level_gap=resolved_level_gap,
+        layer_types=layer_types,
+        color_map=_color_map,
         font=font,
         diagram_height=diagram_height,
         img_template=img_template,
@@ -418,6 +433,11 @@ def _draw_diagram_frame(
     padding: int,
     show_dimension: bool,
     font_color: str | tuple[int, ...],
+    legend: bool,
+    shade_step: int,
+    opacity: int,
+    spacing: int,
+    background_fill: str | tuple[int, ...],
 ) -> PIL.Image:
     """Draw a single frame: everything in columns `0..reveal_up_to`, on a copy of the shared canvas.
 
@@ -467,6 +487,20 @@ def _draw_diagram_frame(
     if show_dimension:
         img = _draw_labels(img, visible_boxes_by_column, setup.font, font_color)
 
+    if legend:
+        img = _draw_legend(
+            img,
+            setup.layer_types,
+            setup.color_map,
+            setup.font,
+            font_color,
+            shade_step,
+            opacity,
+            spacing,
+            padding,
+            background_fill,
+        )
+
     return img
 
 
@@ -501,6 +535,7 @@ def _lenet_view_animate(
     connector_fill: str | tuple[int, ...] | None = None,
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
+    legend: bool = False,
     frame_duration: int = 600,
     final_hold_duration: int = 1500,
     loop: bool = True,
@@ -568,6 +603,7 @@ def _lenet_view_animate(
             or a tuple (R, G, B, A). If None, inherits the target box's outline color.
         connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
+        legend (bool, optional): If True, append a fixed layer-color legend using stacked-plane swatches.
         frame_duration (int, optional): Milliseconds each intermediate frame is displayed.
         final_hold_duration (int, optional): Milliseconds the final, fully-revealed frame is
             displayed before the GIF loops - gives a viewer time to actually see the complete
@@ -623,6 +659,11 @@ def _lenet_view_animate(
             padding,
             show_dimension,
             font_color,
+            legend,
+            shade_step,
+            opacity,
+            spacing,
+            background_fill,
         )
 
     return animate_frames(
@@ -868,3 +909,66 @@ def _draw_labels(
             draw_text.text((loc_x, img.height - 50), f"{label} {shape_label}", font=font, fill=font_color)
 
     return Image.alpha_composite(img, text_img)
+
+
+def _draw_legend(
+    img: PIL.Image,
+    layer_types: list[type],
+    color_map: dict,
+    font: ImageFont,
+    font_color: str | tuple[int, ...],
+    shade_step: int,
+    opacity: int,
+    spacing: int,
+    padding: int,
+    background_fill: str | tuple[int, ...],
+) -> PIL.Image:
+    """Append a color legend whose swatches match LeNet's stacked planes."""
+    text_height = font.getbbox("Ag")[3]
+    swatch_size = text_height
+    stack_depth = 3
+    stack_offset = max(1, swatch_size // 6)
+    stack_extent = (stack_depth - 1) * stack_offset
+    patch_height = swatch_size + stack_extent
+    patches = []
+
+    for layer_type in layer_types:
+        label = layer_type.__name__
+        text_width = font.getbbox(label)[2]
+        patch_size = (swatch_size + stack_extent + spacing + text_width, patch_height)
+        patch = Image.new("RGBA", patch_size, background_fill)
+        text_layer = Image.new("RGBA", patch_size, (0, 0, 0, 0))
+        shape_draw = aggdraw.Draw(patch)
+        text_draw = ImageDraw.Draw(text_layer)
+
+        swatch = StackedBox()
+        swatch.de = stack_depth
+        swatch.offset_z = stack_offset
+        swatch.shade = shade_step
+        initial_offset = -swatch.offset_z * swatch.de // 2
+        swatch.x1 = -initial_offset
+        swatch.y1 = -initial_offset
+        swatch.x2 = swatch.x1 + swatch_size
+        swatch.y2 = swatch.y1 + swatch_size
+        swatch.set_fill(color_map[layer_type]["fill"], opacity)
+        swatch.outline = color_map[layer_type]["outline"]
+        swatch.draw(shape_draw)
+
+        text_x = swatch_size + stack_extent + spacing
+        text_y = (patch_size[1] - text_height) / 2
+        text_draw.text((text_x, text_y), label, font=font, fill=font_color)
+
+        shape_draw.flush()
+        patch.paste(text_layer, mask=text_layer)
+        patches.append(patch)
+
+    legend_image = linear_layout(
+        patches,
+        max_width=img.width,
+        max_height=img.height,
+        padding=padding,
+        spacing=spacing,
+        background_fill=background_fill,
+        horizontal=True,
+    )
+    return vertical_image_concat(img, legend_image, background_fill)

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -68,6 +68,7 @@ class GraphStyleOptions:
     show_dimension: bool = False
     show_input: bool = True
     show_arrows: bool = False
+    legend: bool = False
 
 
 @dataclass
@@ -118,6 +119,7 @@ class LenetStyleOptions:
     connector_fill: str | tuple[int, ...] | None = None
     connector_width: int = 1
     one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
+    legend: bool = False
 
 
 def _render_graph(
@@ -151,6 +153,7 @@ def _render_graph(
         font_color=common.font_color,
         level_gap=common.level_gap,
         show_input=options.show_input,
+        legend=options.legend,
     )
 
 
@@ -233,6 +236,7 @@ def _render_lenet(
         connector_fill=options.connector_fill,
         connector_width=options.connector_width,
         one_dim_orientation=options.one_dim_orientation,
+        legend=options.legend,
     )
 
 


### PR DESCRIPTION
Closes #113

Adds `legend=True` to the graph and LeNet renderers. Graph uses circular swatches, while LeNet uses stacked-plane swatches, so each legend matches its diagram style. The option is also available through `render()` and animations.

## Tests

- `python -m pytest` - 255 passed
