### PR TITLE
docs: pin README logo image to its actual commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
- <h1><img src="https://raw.githubusercontent.com/willyfh/visualtorch/PENDING_COMMIT_SHA/docs/source/_static/images/logos/traced-flame-readme.png" width="40" style="vertical-align: middle" alt="VisualTorch logo"> VisualTorch</h1>
+ <h1><img src="https://raw.githubusercontent.com/willyfh/visualtorch/ad89524/docs/source/_static/images/logos/traced-flame-readme.png" width="40" style="vertical-align: middle" alt="VisualTorch logo"> VisualTorch</h1>
 
 [![python](https://img.shields.io/badge/python-3.10%2B-blue)]() [![pytorch](https://img.shields.io/badge/pytorch-2.0%2B-orange)]() [![Downloads](https://static.pepy.tech/personalized-badge/visualtorch?period=total&units=international_system&left_color=grey&right_color=green&left_text=PyPI%20Downloads)](https://pepy.tech/project/visualtorch) [![Run Tests](https://github.com/willyfh/visualtorch/actions/workflows/pytest.yml/badge.svg)](https://github.com/willyfh/visualtorch/actions/workflows/pytest.yml) [![Documentation Status](https://readthedocs.org/projects/visualtorch/badge/?version=latest)](https://visualtorch.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
## Summary
Follow-up to #177 - the README logo `<img>` src had a `PENDING_COMMIT_SHA` placeholder since the real SHA wasn't known until after that PR's squash-merge. Pins it to `ad89524` (the actual merge commit), matching this repo's existing convention for static banner images (`readme-examples.png`/`readme-animated-demo.gif`).

## Test plan
- [x] Verified the pinned raw.githubusercontent.com URL resolves (HTTP 200)
- [x] `pre-commit run --files README.md` clean