### PR TITLE
fix: use scoped PAT for star history API auth

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate chart
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
         run: python scripts/generate_star_history.py
 
       - name: Push chart to assets branch


### PR DESCRIPTION
## Summary
The daily star-history workflow has failed for 2 days straight with HTTP 403 fetching stargazer timestamps. Confirmed the cause directly: the \`Accept: application/vnd.github.star+json\` endpoint requires auth (401 unauthenticated), and the default \`secrets.GITHUB_TOKEN\` is no longer sufficient for it - likely a GitHub-side tightening around exposing other users' star timestamps.

Switches the workflow to a scoped classic PAT (\`public_repo\` only) stored as \`STAR_HISTORY_TOKEN\`, added as a repo secret separately.

## Test plan
- [x] Confirmed via direct curl: unauthenticated -> 401, authenticated -> 200
- [x] `pre-commit run --files .github/workflows/star-history.yml` clean
- [ ] Trigger `workflow_dispatch` after merge to confirm the daily job succeeds