### PR TITLE
Add legend positioning to graph and LeNet views

### DIFF
--- a/docs/examples/graph/plot_legend_position_graph.py
+++ b/docs/examples/graph/plot_legend_position_graph.py
@@ -1,0 +1,55 @@
+"""Legend Position
+=======================================
+
+Place the graph legend above or below the diagram, aligned left, center, or right.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+
+input_shape = (1, 3, 32, 32)
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+
+
+def _show(position: str) -> None:
+    img = visualtorch.render(
+        model,
+        input_shape=input_shape,
+        style="graph",
+        show_neurons=False,
+        legend=True,
+        legend_position=position,
+        layer_spacing=400,
+    )
+    plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+    plt.imshow(img)
+    plt.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+# %%
+# Top-left
+# --------
+
+_show("top-left")
+
+# %%
+# Top-center
+# ----------
+
+_show("top-center")
+
+# %%
+# Bottom-right
+# ------------
+
+_show("bottom-right")

--- a/docs/examples/lenet_style/plot_legend_position_lenet_style.py
+++ b/docs/examples/lenet_style/plot_legend_position_lenet_style.py
@@ -1,0 +1,55 @@
+"""Legend Position
+=======================================
+
+Place the LeNet-style legend above or below the diagram, aligned left, center, or right.
+"""  # noqa: D205
+
+import matplotlib.pyplot as plt
+import visualtorch
+from torch import nn
+
+model = nn.Sequential(
+    nn.Conv2d(3, 8, kernel_size=3, padding=1),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(8, 16, kernel_size=3, padding=1),
+    nn.ReLU(),
+)
+
+input_shape = (1, 3, 32, 32)
+dpi = 150  # rendered at 2x this in the final doc build (savefig.dpi=300 in conf.py)
+
+
+def _show(position: str) -> None:
+    img = visualtorch.render(
+        model,
+        input_shape=input_shape,
+        style="lenet",
+        legend=True,
+        legend_position=position,
+        spacing=60,
+    )
+    plt.figure(figsize=(img.width / dpi, img.height / dpi), dpi=dpi)
+    plt.imshow(img)
+    plt.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+# %%
+# Top-left
+# --------
+
+_show("top-left")
+
+# %%
+# Top-center
+# ----------
+
+_show("top-center")
+
+# %%
+# Bottom-right
+# ------------
+
+_show("bottom-right")

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -203,6 +203,20 @@ def test_graph_and_lenet_legends_are_fixed_from_first_frame(style: str) -> None:
     assert legend_crop(frames[0]).tobytes() == legend_crop(frames[-1]).tobytes()
 
 
+@pytest.mark.parametrize("style", ["graph", "lenet"])
+def test_graph_and_lenet_animate_forwards_legend_position(style: str) -> None:
+    """Animated graph and LeNet renders should place legends like static renders."""
+    model = nn.Sequential(nn.Conv2d(3, 4, 3, 1, 1), nn.BatchNorm2d(4), nn.ReLU())
+    input_shape = (1, 3, 8, 8)
+
+    static_top = _STATIC_VIEW_FUNCS[style](model, input_shape, legend=True, legend_position="top-left")
+    static_bottom = _STATIC_VIEW_FUNCS[style](model, input_shape, legend=True, legend_position="bottom-left")
+    frames = animate(model, input_shape, style=style, legend=True, legend_position="top-left")
+
+    assert frames[-1].tobytes() == static_top.tobytes()
+    assert frames[-1].tobytes() != static_bottom.tobytes()
+
+
 @pytest.mark.parametrize("style", _STYLES)
 def test_show_dimension_labels_appear_with_their_column(style: str, sequential_model: nn.Module) -> None:
     """A column's shape label appears exactly when that column's boxes do, not before."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -437,6 +437,87 @@ def test_graph_view_with_legend(conv_model: nn.Module) -> None:
     assert with_legend.height > without_legend.height
 
 
+@pytest.mark.parametrize(
+    "legend_position",
+    ["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"],
+)
+def test_graph_view_with_legend_position(conv_model: nn.Module, legend_position: str) -> None:
+    """legend_position should accept every documented top/bottom alignment."""
+    img = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position=legend_position,
+    )
+
+    assert img is not None
+
+
+def test_graph_view_default_legend_position_matches_bottom_left(conv_model: nn.Module) -> None:
+    """The default legend placement should preserve the previous bottom-left layout."""
+    default = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False, legend=True)
+    explicit = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert default.tobytes() == explicit.tobytes()
+
+
+def test_graph_view_legend_position_moves_legend_vertically(conv_model: nn.Module) -> None:
+    """Top and bottom legend placements should produce different layouts."""
+    top = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position="top-left",
+    )
+    bottom = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert top.size == bottom.size
+    assert top.tobytes() != bottom.tobytes()
+
+
+def test_graph_view_legend_position_moves_legend_horizontally(conv_model: nn.Module) -> None:
+    """Left and right legend placements should align the legend within the available width."""
+    left = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position="bottom-left",
+        layer_spacing=400,
+    )
+    right = graph_view(
+        conv_model,
+        input_shape=(1, 3, 16, 16),
+        show_neurons=False,
+        legend=True,
+        legend_position="bottom-right",
+        layer_spacing=400,
+    )
+
+    assert left.size == right.size
+    assert left.tobytes() != right.tobytes()
+
+
+def test_graph_view_invalid_legend_position_raises(conv_model: nn.Module) -> None:
+    """Invalid legend positions should fail with a targeted error."""
+    with pytest.raises(ValueError, match="legend_position"):
+        graph_view(conv_model, input_shape=(1, 3, 16, 16), legend=True, legend_position="left")
+
+
 def test_graph_view_legend_false_preserves_default(conv_model: nn.Module) -> None:
     """The opt-in legend must not change graph_view's default output."""
     default = graph_view(conv_model, input_shape=(1, 3, 16, 16), show_neurons=False)

--- a/tests/test_lenet_style.py
+++ b/tests/test_lenet_style.py
@@ -238,6 +238,92 @@ def test_lenet_view_with_legend(small_sequential_model: nn.Sequential) -> None:
     assert with_legend.height > without_legend.height
 
 
+@pytest.mark.parametrize(
+    "legend_position",
+    ["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"],
+)
+def test_lenet_view_with_legend_position(small_sequential_model: nn.Sequential, legend_position: str) -> None:
+    """legend_position should accept every documented top/bottom alignment."""
+    img = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position=legend_position,
+    )
+
+    assert img is not None
+
+
+def test_lenet_view_default_legend_position_matches_bottom_left(small_sequential_model: nn.Sequential) -> None:
+    """The default legend placement should preserve the previous bottom-left layout."""
+    default = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+    )
+    explicit = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert default.tobytes() == explicit.tobytes()
+
+
+def test_lenet_view_legend_position_moves_legend_vertically(small_sequential_model: nn.Sequential) -> None:
+    """Top and bottom legend placements should produce different layouts."""
+    top = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position="top-left",
+    )
+    bottom = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert top.size == bottom.size
+    assert top.tobytes() != bottom.tobytes()
+
+
+def test_lenet_view_legend_position_moves_legend_horizontally(small_sequential_model: nn.Sequential) -> None:
+    """Left and right legend placements should align the legend within the available width."""
+    left = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position="bottom-left",
+        spacing=60,
+    )
+    right = lenet_view(
+        small_sequential_model,
+        input_shape=(1, 3, 16, 16),
+        show_dimension=False,
+        legend=True,
+        legend_position="bottom-right",
+        spacing=60,
+    )
+
+    assert left.size == right.size
+    assert left.tobytes() != right.tobytes()
+
+
+def test_lenet_view_invalid_legend_position_raises(small_sequential_model: nn.Sequential) -> None:
+    """Invalid legend positions should fail with a targeted error."""
+    with pytest.raises(ValueError, match="legend_position"):
+        lenet_view(small_sequential_model, input_shape=(1, 3, 16, 16), legend=True, legend_position="left")
+
+
 def test_lenet_view_legend_false_preserves_default(small_sequential_model: nn.Sequential) -> None:
     """The opt-in legend must not change lenet_view's default output."""
     default = lenet_view(small_sequential_model, input_shape=(1, 3, 16, 16))

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -85,6 +85,15 @@ def test_static_capabilities_match_public_visualtorch_contracts() -> None:
                 assert advertised[name]["default"] == field.default
 
     assert capabilities["palettes"] == {name: list(colors) for name, colors in sorted(visualtorch.PALETTES.items())}
+    for style in option_types:
+        assert capabilities["styles"][style]["options"]["legend_position"]["enum"] == [
+            "top-left",
+            "top-right",
+            "top-center",
+            "bottom-left",
+            "bottom-right",
+            "bottom-center",
+        ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -134,6 +134,28 @@ def test_render_forwards_flow_legend_position(sequential_model: nn.Sequential) -
     assert top.tobytes() != bottom.tobytes()
 
 
+@pytest.mark.parametrize("style", ["graph", "lenet"])
+def test_render_forwards_graph_and_lenet_legend_position(sequential_model: nn.Sequential, style: str) -> None:
+    """Graph and LeNet styles should accept and forward legend_position through render()."""
+    top = render(
+        sequential_model,
+        input_shape=(1, 3, 16, 16),
+        style=style,
+        legend=True,
+        legend_position="top-left",
+    )
+    bottom = render(
+        sequential_model,
+        input_shape=(1, 3, 16, 16),
+        style=style,
+        legend=True,
+        legend_position="bottom-left",
+    )
+
+    assert top.size == bottom.size
+    assert top.tobytes() != bottom.tobytes()
+
+
 def test_render_rejects_malformed_mixed_input_shape_with_clear_error(sequential_model: nn.Sequential) -> None:
     """A shape tuple mixing raw ints and nested shape-tuples at the top level is ambiguous and
     should raise a clear ValueError rather than being silently misinterpreted.

--- a/visualtorch/_legend.py
+++ b/visualtorch/_legend.py
@@ -1,0 +1,59 @@
+"""Shared legend placement helpers."""
+
+# Copyright (C) 2024 VisualTorch Contributors
+# SPDX-License-Identifier: MIT
+
+from typing import Literal
+
+from PIL import Image
+
+LegendPosition = Literal["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"]
+LEGEND_POSITIONS: tuple[LegendPosition, ...] = (
+    "top-left",
+    "top-right",
+    "top-center",
+    "bottom-left",
+    "bottom-right",
+    "bottom-center",
+)
+
+
+def validate_legend_position(legend_position: str) -> None:
+    """Raise a targeted error for unsupported legend placement values."""
+    if legend_position not in LEGEND_POSITIONS:
+        supported = ", ".join(f"{position!r}" for position in LEGEND_POSITIONS)
+        error_msg = f"unsupported legend_position: {legend_position!r}. Supported positions: {supported}."
+        raise ValueError(error_msg)
+
+
+def place_legend(
+    img: Image.Image,
+    legend_image: Image.Image,
+    legend_position: LegendPosition,
+    background_fill: str | tuple[int, ...],
+) -> Image.Image:
+    """Place the legend outside the diagram while aligning it within the final canvas."""
+    vertical_position, horizontal_position = legend_position.split("-", 1)
+    canvas = Image.new(
+        "RGBA",
+        (max(img.width, legend_image.width), img.height + legend_image.height),
+        background_fill,
+    )
+    legend_x = _horizontal_legend_offset(canvas.width, legend_image.width, horizontal_position)
+
+    if vertical_position == "top":
+        canvas.paste(legend_image, (legend_x, 0))
+        canvas.paste(img, (0, legend_image.height))
+    else:
+        canvas.paste(img, (0, 0))
+        canvas.paste(legend_image, (legend_x, img.height))
+    return canvas
+
+
+def _horizontal_legend_offset(canvas_width: int, legend_width: int, horizontal_position: str) -> int:
+    """Return the x offset for the legend row inside the final canvas."""
+    if horizontal_position == "right":
+        return canvas_width - legend_width
+    if horizontal_position == "center":
+        return (canvas_width - legend_width) // 2
+    return 0

--- a/visualtorch/flow.py
+++ b/visualtorch/flow.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from math import ceil
-from typing import Literal
 
 import aggdraw
 import PIL
@@ -17,6 +16,7 @@ from PIL import Image, ImageFont
 from torch import nn
 
 from ._animation import animate_frames
+from ._legend import LegendPosition, place_legend, validate_legend_position
 from ._volumetric_layout import ColumnLayout, VolumetricBox, layout_columns
 from .backend import Architecture, extract_architecture
 from .connectors import compute_skip_levels, draw_connector
@@ -32,16 +32,6 @@ from .utils.utils import (
     linear_layout,
     resolve_palette,
     self_multiply,
-)
-
-LegendPosition = Literal["top-left", "top-right", "top-center", "bottom-left", "bottom-right", "bottom-center"]
-_LEGEND_POSITIONS: tuple[LegendPosition, ...] = (
-    "top-left",
-    "top-right",
-    "top-center",
-    "bottom-left",
-    "bottom-right",
-    "bottom-center",
 )
 
 
@@ -327,7 +317,7 @@ def _prepare_flow_render(
     background_fill: str | tuple[int, ...],
 ) -> _FlowRenderSetup:
     """Trace the model and compute the full layout/canvas once - shared by every frame."""
-    _validate_legend_position(legend_position)
+    validate_legend_position(legend_position)
 
     if one_dim_orientation is not None:
         warnings.warn(
@@ -717,13 +707,6 @@ def _flow_view_animate(
     )
 
 
-def _validate_legend_position(legend_position: str) -> None:
-    if legend_position not in _LEGEND_POSITIONS:
-        supported = ", ".join(f"{position!r}" for position in _LEGEND_POSITIONS)
-        error_msg = f"unsupported legend_position: {legend_position!r}. Supported positions: {supported}."
-        raise ValueError(error_msg)
-
-
 def _box_factory(
     low_dim_orientation: str,
     scale_xy: float,
@@ -981,40 +964,7 @@ def _draw_legend(
         background_fill=background_fill,
         horizontal=True,
     )
-    return _place_legend(img, legend_image, legend_position, background_fill)
-
-
-def _place_legend(
-    img: PIL.Image,
-    legend_image: PIL.Image,
-    legend_position: LegendPosition,
-    background_fill: str | tuple[int, ...],
-) -> PIL.Image:
-    """Place the legend outside the diagram while aligning it within the final canvas."""
-    vertical_position, horizontal_position = legend_position.split("-", 1)
-    canvas = Image.new(
-        "RGBA",
-        (max(img.width, legend_image.width), img.height + legend_image.height),
-        background_fill,
-    )
-    legend_x = _horizontal_legend_offset(canvas.width, legend_image.width, horizontal_position)
-
-    if vertical_position == "top":
-        canvas.paste(legend_image, (legend_x, 0))
-        canvas.paste(img, (0, legend_image.height))
-    else:
-        canvas.paste(img, (0, 0))
-        canvas.paste(legend_image, (legend_x, img.height))
-    return canvas
-
-
-def _horizontal_legend_offset(canvas_width: int, legend_width: int, horizontal_position: str) -> int:
-    """Return the x offset for the legend row inside the final canvas."""
-    if horizontal_position == "right":
-        return canvas_width - legend_width
-    if horizontal_position == "center":
-        return (canvas_width - legend_width) // 2
-    return 0
+    return place_legend(img, legend_image, legend_position, background_fill)
 
 
 def _column_label_and_center(column: list[VolumetricBox]) -> tuple[str, float]:

--- a/visualtorch/graph.py
+++ b/visualtorch/graph.py
@@ -15,6 +15,7 @@ import torch
 from PIL import Image, ImageFont
 
 from ._animation import animate_frames
+from ._legend import LegendPosition, place_legend, validate_legend_position
 from .backend import extract_architecture
 from .connectors import compute_skip_levels, draw_connector
 from .utils.traced_layer import TracedLayer
@@ -29,7 +30,6 @@ from .utils.utils import (
     format_shape_label,
     linear_layout,
     resolve_palette,
-    vertical_image_concat,
 )
 
 
@@ -59,6 +59,7 @@ def graph_view(
     show_input: bool = True,
     show_arrows: bool = False,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
 ) -> Image.Image:
     """Generates an architecture visualization for a given linear PyTorch model in a graph style.
 
@@ -98,6 +99,7 @@ def graph_view(
         show_input,
         show_arrows,
         legend,
+        legend_position,
     )
 
 
@@ -127,6 +129,7 @@ def _graph_view(
     show_input: bool = True,
     show_arrows: bool = False,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
 ) -> Image.Image:
     """The actual graph_view implementation.
 
@@ -182,10 +185,15 @@ def _graph_view(
         show_arrows (bool, optional): If True, draw a small arrowhead at each connector's
             downstream endpoint to indicate data-flow direction.
         legend (bool, optional): If True, append a layer-color legend using circular swatches.
+        legend_position (str, optional): Where to place the legend when `legend=True`. One of
+            "top-left", "top-right", "top-center", "bottom-left", "bottom-right", or
+            "bottom-center". Defaults to "bottom-left", which preserves the original layout.
 
     Returns:
         Image.Image: Generated architecture image.
     """
+    validate_legend_position(legend_position)
+
     setup = _prepare_render(
         model,
         input_shape,
@@ -223,6 +231,7 @@ def _graph_view(
         opacity=opacity,
         spacing=node_spacing,
         background_fill=background_fill,
+        legend_position=legend_position,
     )
 
     if to_file is not None:
@@ -401,6 +410,7 @@ def _draw_architecture_frame(
     opacity: int,
     spacing: int,
     background_fill: str | tuple[int, ...],
+    legend_position: LegendPosition,
 ) -> Image.Image:
     """Draw a single frame: everything in columns `0..reveal_up_to`, on a copy of the shared canvas.
 
@@ -451,6 +461,7 @@ def _draw_architecture_frame(
             spacing,
             padding,
             background_fill,
+            legend_position,
         )
 
     return img
@@ -482,6 +493,7 @@ def _graph_view_animate(
     show_input: bool = True,
     show_arrows: bool = False,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
     frame_duration: int = 600,
     final_hold_duration: int = 1500,
     loop: bool = True,
@@ -540,6 +552,9 @@ def _graph_view_animate(
         show_arrows (bool, optional): If True, draw a small arrowhead at each connector's
             downstream endpoint to indicate data-flow direction.
         legend (bool, optional): If True, append a fixed layer-color legend using circular swatches.
+        legend_position (str, optional): Where to place the legend when `legend=True`. One of
+            "top-left", "top-right", "top-center", "bottom-left", "bottom-right", or
+            "bottom-center". Defaults to "bottom-left", which preserves the original layout.
         frame_duration (int, optional): Milliseconds each intermediate frame is displayed.
         final_hold_duration (int, optional): Milliseconds the final, fully-revealed frame is
             displayed before the GIF loops - gives a viewer time to actually see the complete
@@ -557,6 +572,8 @@ def _graph_view_animate(
         when also writing to a file. `to_file` should end in `.gif`; a mismatched extension will
         not raise, it will silently save only the first frame.
     """
+    validate_legend_position(legend_position)
+
     setup = _prepare_render(
         model,
         input_shape,
@@ -595,6 +612,7 @@ def _graph_view_animate(
             opacity,
             node_spacing,
             background_fill,
+            legend_position,
         )
 
     return animate_frames(
@@ -753,6 +771,7 @@ def _draw_legend(
     spacing: int,
     padding: int,
     background_fill: str | tuple[int, ...],
+    legend_position: LegendPosition,
 ) -> Image.Image:
     """Append a color legend whose swatches match graph nodes."""
     text_height = font.getbbox("Ag")[3]
@@ -791,7 +810,7 @@ def _draw_legend(
         background_fill=background_fill,
         horizontal=True,
     )
-    return vertical_image_concat(img, legend_image, background_fill)
+    return place_legend(img, legend_image, legend_position, background_fill)
 
 
 def _retrieve_isbox_units(layer: TracedLayer, show_neurons: bool) -> tuple[bool, int]:

--- a/visualtorch/lenet_style.py
+++ b/visualtorch/lenet_style.py
@@ -15,6 +15,7 @@ from PIL import Image, ImageFont
 from torch import nn
 
 from ._animation import animate_frames
+from ._legend import LegendPosition, place_legend, validate_legend_position
 from ._volumetric_layout import ColumnLayout, VolumetricBox, layout_columns
 from .backend import Architecture, extract_architecture
 from .connectors import compute_skip_levels, draw_connector
@@ -31,7 +32,6 @@ from .utils.utils import (
     linear_layout,
     resolve_palette,
     self_multiply,
-    vertical_image_concat,
 )
 
 _LABEL_ROW_HEIGHT = 100
@@ -69,6 +69,7 @@ def lenet_view(
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
 ) -> PIL.Image:
     """Generate a LeNet style architecture visualization for a given torch model.
 
@@ -114,6 +115,7 @@ def lenet_view(
         connector_width,
         one_dim_orientation,
         legend,
+        legend_position,
     )
 
 
@@ -149,6 +151,7 @@ def _lenet_view(
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
 ) -> PIL.Image:
     """The actual lenet_view implementation.
 
@@ -215,10 +218,15 @@ def _lenet_view(
         connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
         legend (bool, optional): If True, append a layer-color legend using stacked-plane swatches.
+        legend_position (str, optional): Where to place the legend when `legend=True`. One of
+            "top-left", "top-right", "top-center", "bottom-left", "bottom-right", or
+            "bottom-center". Defaults to "bottom-left", which preserves the original layout.
 
     Returns:
         PIL.Image: An Image object representing the generated architecture visualization.
     """
+    validate_legend_position(legend_position)
+
     setup = _prepare_lenet_render(
         model,
         input_shape,
@@ -261,6 +269,7 @@ def _lenet_view(
         opacity=opacity,
         spacing=spacing,
         background_fill=background_fill,
+        legend_position=legend_position,
     )
 
     if to_file is not None:
@@ -438,6 +447,7 @@ def _draw_diagram_frame(
     opacity: int,
     spacing: int,
     background_fill: str | tuple[int, ...],
+    legend_position: LegendPosition,
 ) -> PIL.Image:
     """Draw a single frame: everything in columns `0..reveal_up_to`, on a copy of the shared canvas.
 
@@ -499,6 +509,7 @@ def _draw_diagram_frame(
             spacing,
             padding,
             background_fill,
+            legend_position,
         )
 
     return img
@@ -536,6 +547,7 @@ def _lenet_view_animate(
     connector_width: int = 1,
     one_dim_orientation: str | None = None,
     legend: bool = False,
+    legend_position: LegendPosition = "bottom-left",
     frame_duration: int = 600,
     final_hold_duration: int = 1500,
     loop: bool = True,
@@ -604,6 +616,9 @@ def _lenet_view_animate(
         connector_width (int, optional): Line width in pixels for funnel and skip-connection lines. Defaults to 1.
         one_dim_orientation (str, optional): Deprecated, use `low_dim_orientation` instead.
         legend (bool, optional): If True, append a fixed layer-color legend using stacked-plane swatches.
+        legend_position (str, optional): Where to place the legend when `legend=True`. One of
+            "top-left", "top-right", "top-center", "bottom-left", "bottom-right", or
+            "bottom-center". Defaults to "bottom-left", which preserves the original layout.
         frame_duration (int, optional): Milliseconds each intermediate frame is displayed.
         final_hold_duration (int, optional): Milliseconds the final, fully-revealed frame is
             displayed before the GIF loops - gives a viewer time to actually see the complete
@@ -621,6 +636,8 @@ def _lenet_view_animate(
         writing to a file. `to_file` should end in `.gif`; a mismatched extension will not raise,
         it will silently save only the first frame.
     """
+    validate_legend_position(legend_position)
+
     setup = _prepare_lenet_render(
         model,
         input_shape,
@@ -664,6 +681,7 @@ def _lenet_view_animate(
             opacity,
             spacing,
             background_fill,
+            legend_position,
         )
 
     return animate_frames(
@@ -922,6 +940,7 @@ def _draw_legend(
     spacing: int,
     padding: int,
     background_fill: str | tuple[int, ...],
+    legend_position: LegendPosition,
 ) -> PIL.Image:
     """Append a color legend whose swatches match LeNet's stacked planes."""
     text_height = font.getbbox("Ag")[3]
@@ -971,4 +990,4 @@ def _draw_legend(
         background_fill=background_fill,
         horizontal=True,
     )
-    return vertical_image_concat(img, legend_image, background_fill)
+    return place_legend(img, legend_image, legend_position, background_fill)

--- a/visualtorch/render.py
+++ b/visualtorch/render.py
@@ -28,7 +28,8 @@ from typing import Any, Literal
 from PIL import Image
 from torch import nn
 
-from .flow import LegendPosition, _flow_view, _flow_view_animate
+from ._legend import LegendPosition
+from .flow import _flow_view, _flow_view_animate
 from .graph import _graph_view, _graph_view_animate
 from .lenet_style import _lenet_view, _lenet_view_animate
 from .utils.utils import InputDtype, InputShape
@@ -69,6 +70,7 @@ class GraphStyleOptions:
     show_input: bool = True
     show_arrows: bool = False
     legend: bool = False
+    legend_position: LegendPosition = "bottom-left"
 
 
 @dataclass
@@ -120,6 +122,7 @@ class LenetStyleOptions:
     connector_width: int = 1
     one_dim_orientation: str | None = None  # deprecated, use low_dim_orientation
     legend: bool = False
+    legend_position: LegendPosition = "bottom-left"
 
 
 def _render_graph(
@@ -154,6 +157,7 @@ def _render_graph(
         level_gap=common.level_gap,
         show_input=options.show_input,
         legend=options.legend,
+        legend_position=options.legend_position,
     )
 
 
@@ -237,6 +241,7 @@ def _render_lenet(
         connector_width=options.connector_width,
         one_dim_orientation=options.one_dim_orientation,
         legend=options.legend,
+        legend_position=options.legend_position,
     )
 
 

--- a/visualtorch_mcp/api_reference.py
+++ b/visualtorch_mcp/api_reference.py
@@ -65,6 +65,7 @@ STYLE_OPTION_SPECS: dict[str, dict[str, tuple[str, object]]] = {
         "show_input": ("boolean", True),
         "show_arrows": ("boolean", False),
         "legend": ("boolean", False),
+        "legend_position": ("string", "bottom-left"),
     },
     "flow": {
         "min_z": ("integer", 10),
@@ -108,6 +109,7 @@ STYLE_OPTION_SPECS: dict[str, dict[str, tuple[str, object]]] = {
         "connector_width": ("integer", 1),
         "one_dim_orientation": ("string | null", None),
         "legend": ("boolean", False),
+        "legend_position": ("string", "bottom-left"),
     },
 }
 
@@ -192,7 +194,7 @@ OPTION_DESCRIPTIONS = {
     "draw_funnel": "Draw funnel-shaped connectors between layers.",
     "shade_step": "Brightness step applied to shaded layer faces.",
     "legend": "Add a layer-color legend to the diagram.",
-    "legend_position": "Legend placement around the rendered flow diagram.",
+    "legend_position": "Legend placement above or below the rendered diagram, aligned left, center, or right.",
     "one_dim_orientation": "Deprecated alias for low_dim_orientation.",
     "max_channels": "Maximum number of feature-map channels drawn for a LeNet-style layer.",
     "offset_z": "Depth-axis offset between LeNet-style feature-map planes.",


### PR DESCRIPTION
## Summary

- add the existing six-value `legend_position` API to graph and LeNet static and animated views
- share legend validation and canvas placement with the flow view so all three styles stay consistent
- expose the option through `render()`, animation, and the MCP capabilities manifest
- add graph and LeNet gallery examples plus regression coverage for defaults, invalid values, placement, and forwarding

## Verification

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q` — 311 passed
- `.venv/bin/pre-commit run --all-files` — all hooks passed
- `MPLBACKEND=Agg .venv/bin/python docs/examples/graph/plot_legend_position_graph.py`
- `MPLBACKEND=Agg .venv/bin/python docs/examples/lenet_style/plot_legend_position_lenet_style.py`
- `git diff --check`

Closes #185
