### PR TITLE
feat: add MCP Registry listing for VisualTorch

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,48 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate server.json
+
+      - name: Wait for PyPI package ownership marker
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(python3 -c 'import json; print(json.load(open("server.json"))["packages"][0]["version"])')
+          echo "Waiting for visualtorch==${VERSION} on PyPI with mcp-name ownership proof..."
+          for attempt in $(seq 1 30); do
+            desc=$(curl -fsSL "https://pypi.org/pypi/visualtorch/${VERSION}/json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["info"]["description"])' || true)
+            if printf '%s' "$desc" | grep -Fq 'mcp-name: io.github.willyfh/visualtorch'; then
+              echo "Found ownership proof for visualtorch==${VERSION}"
+              exit 0
+            fi
+            echo "Attempt ${attempt}/30: package not ready yet"
+            sleep 20
+          done
+          echo "Timed out waiting for visualtorch==${VERSION} on PyPI with ownership proof" >&2
+          exit 1
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ styles (`graph`, `flow`, and `lenet`). Install it with `pip install "visualtorch
 for the tool schemas, generic stdio configuration, examples, and trusted-code security boundary.
 No client-specific plugin or extension is required.
 
+<!-- mcp-name: io.github.willyfh/visualtorch -->
+
 ## Used in Research
 
 VisualTorch has been used in published research, including works published in Nature, IEEE, and MDPI.

--- a/docs/source/markdown/get_started/mcp.md
+++ b/docs/source/markdown/get_started/mcp.md
@@ -248,3 +248,19 @@ and network access.
 
 VisualTorch deliberately provides this portable stdio MCP surface without bundling configuration,
 authentication, branding, or packaging for any particular MCP host.
+
+## MCP Registry
+
+VisualTorch is prepared for the official MCP Registry as
+`io.github.willyfh/visualtorch`. The package ownership proof is the
+`mcp-name: io.github.willyfh/visualtorch` marker in the project README that ships on PyPI.
+Registry metadata lives in [`server.json`](https://github.com/willyfh/visualtorch/blob/main/server.json)
+at the repository root.
+
+Hosts that consume the registry can install and launch the server with:
+
+```bash
+uvx --from "visualtorch[mcp]" visualtorch-mcp
+```
+
+or by installing `visualtorch[mcp]` and running the `visualtorch-mcp` console script.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.willyfh/visualtorch",
+  "title": "VisualTorch",
+  "description": "Render PyTorch architecture diagrams and animated GIF reveals from trusted model source.",
+  "websiteUrl": "https://visualtorch.readthedocs.io/en/latest/markdown/get_started/mcp.html",
+  "repository": {
+    "url": "https://github.com/willyfh/visualtorch",
+    "source": "github"
+  },
+  "version": "1.4.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "visualtorch",
+      "version": "1.4.1",
+      "runtimeHint": "uvx",
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "--from"
+        },
+        {
+          "type": "positional",
+          "value": "visualtorch[mcp]"
+        },
+        {
+          "type": "positional",
+          "value": "visualtorch-mcp"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read_requirements(file: str) -> list:
 
 setuptools.setup(
     name="visualtorch",
-    version="1.4.0",
+    version="1.4.1",
     author="Willy Fitra Hendria",
     author_email="willyfitrahendria@gmail.com",
     maintainer="VisualTorch Contributors",


### PR DESCRIPTION
## Summary
- Add `server.json` for the official MCP Registry under `io.github.willyfh/visualtorch`
- Add the PyPI ownership proof marker `<!-- mcp-name: io.github.willyfh/visualtorch -->` to the README
- Document the registry install path in the MCP guide
- Add a GitHub Actions workflow that publishes via OIDC after the matching PyPI release is available
- Bump package version to `1.4.1` so the ownership proof can ship on PyPI

## Notes
- `mcp-publisher validate server.json` passes against the official registry schema
- Publishing to the registry requires the ownership proof to be present on the published PyPI package description, so the workflow waits for `visualtorch==1.4.1` after the normal PyPI release workflow
- Once this lands and `v1.4.1` is released, the MCP Registry entry should become discoverable to consumers such as GitHub MCP

## Test plan
- [x] Validate `server.json` with official `mcp-publisher validate`
- [x] Merge and cut `v1.4.1` so the PyPI ownership marker is live
- [x] Confirm the MCP Registry publish workflow succeeds
- [x] Verify `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.willyfh/visualtorch`