### PR TITLE
docs: automate the pip install version snippet, stop manually pinning it

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html#project-informatio
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -20,6 +21,19 @@ module_path = Path(__file__).parent.parent / "src"
 
 # Insert the path to sys.path
 sys.path.insert(0, str(module_path.resolve()))
+
+# Regenerate the pinned `pip install visualtorch==X.Y.Z` snippet from setup.py's version on every
+# doc build, so the Installation page can never show a stale version again (it was missed on 3
+# releases in a row when this was a manually-updated file). Parsed directly from setup.py's source
+# text, not the installed package's metadata - an editable install can report a stale version
+# after a version-bump commit until it's reinstalled, which would silently defeat the point here.
+_setup_py = (Path(__file__).parent.parent.parent / "setup.py").read_text(encoding="utf-8")
+_version_match = re.search(r'version\s*=\s*"([^"]+)"', _setup_py)
+if _version_match is None:
+    message = 'Could not find version="..." in setup.py to regenerate the install snippet.'
+    raise RuntimeError(message)
+_pypi_snippet = Path(__file__).parent / "snippets" / "install" / "pypi.txt"
+_pypi_snippet.write_text(f"pip install visualtorch=={_version_match.group(1)}\n", encoding="utf-8")
 
 # Sphinx-Gallery captures each example's figure via matplotlib's savefig, at whatever DPI is
 # active during the doc build - matplotlib's own default (100) downscales anything larger than

--- a/docs/source/snippets/install/pypi.txt
+++ b/docs/source/snippets/install/pypi.txt
@@ -1,1 +1,1 @@
-pip install visualtorch==1.3.0
+pip install visualtorch==1.4.1

--- a/tests/test_docs_version_sync.py
+++ b/tests/test_docs_version_sync.py
@@ -1,0 +1,35 @@
+"""Guards against the docs install snippet drifting from setup.py's version.
+
+`docs/source/snippets/install/pypi.txt` is regenerated automatically from setup.py's version on
+every Sphinx build (see docs/source/conf.py), so this shouldn't drift in practice. This test is a
+cheap, build-independent safety net for the case where docs get built some other way that skips
+conf.py's normal execution - it was manually maintained and missed on 3 releases in a row before
+the auto-regeneration was added.
+"""
+
+# Copyright (C) 2024 VisualTorch Contributors
+# SPDX-License-Identifier: MIT
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _setup_py_version() -> str:
+    setup_py = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+    match = re.search(r'version\s*=\s*"([^"]+)"', setup_py)
+    assert match is not None, 'Could not find version="..." in setup.py.'
+    return match.group(1)
+
+
+def test_pypi_install_snippet_matches_setup_py_version() -> None:
+    """The pinned `pip install visualtorch==X.Y.Z` snippet must match setup.py's version."""
+    snippet_path = REPO_ROOT / "docs" / "source" / "snippets" / "install" / "pypi.txt"
+    snippet = snippet_path.read_text(encoding="utf-8").strip()
+    expected = f"pip install visualtorch=={_setup_py_version()}"
+
+    assert snippet == expected, (
+        f"{snippet_path} is stale - run a docs build to regenerate it, "
+        f"or update it to match setup.py's version ({_setup_py_version()})."
+    )


### PR DESCRIPTION
pypi.txt's pinned version was stale (missed 3 releases in a row).

- Bumps it to 1.4.1
- conf.py now regenerates it from setup.py on every doc build, so it can't go stale again
- Added a test asserting they match, as a backup

Reads setup.py's source directly, not installed metadata, so it stays correct even if someone forgets to reinstall after bumping the version.