### PR TITLE
fix: pin prettier as a local hook so autoupdate can't propose alpha bumps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,20 @@ repos:
         additional_dependencies: [types-PyYAML]
         exclude: "tests"
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  # A `local` hook instead of the `mirrors-prettier` repo mirror: that mirror only has alpha
+  # pre-releases past v3.1.0 (prettier hasn't cut a stable v4 yet), and pre-commit.ci's autoupdate
+  # always jumps to the highest available tag regardless of pre-release status - repeatedly
+  # proposing a broken v4.0.0-alpha.x bump (see #168, #188, #192, #200). A `local` hook has no
+  # `rev` for autoupdate to touch, so it's pinned here until manually bumped to a real stable
+  # release.
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: prettier --write --list-different --ignore-unknown
+        language: node
+        types: [text]
+        additional_dependencies: ["prettier@3.1.0"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.49.1


### PR DESCRIPTION
## Summary
- pre-commit.ci's autoupdate always jumps to the highest available tag on the `mirrors-prettier` repo, which only has v4 alpha pre-releases past v3.1.0 (prettier hasn't cut a stable v4 yet). This has repeatedly produced broken autoupdate PRs proposing a `v4.0.0-alpha.x` bump (#168, #188, #192, #200), requiring a manual revert each time.
- Converts the prettier hook to a `repo: local` hook, npm-pinned to `prettier@3.1.0` directly instead of tracked via the mirror's git tags. A local hook has no `rev` for autoupdate to touch, so this stops the recurring bad-bump PRs at the source rather than reverting them each time they appear.
- Verified identical behavior: `pre-commit run prettier --all-files` produces zero diffs on the current tree (same prettier version, same args), and the full `pre-commit run --all-files` suite passes.

## Test plan
- [x] `pre-commit run prettier --all-files` - passes, no formatting diffs vs. the previous mirror-based hook
- [x] `pre-commit run --all-files` (full suite) - all hooks pass